### PR TITLE
ENH : add qt compatibility

### DIFF
--- a/src/nexpy/examples/plugins/chopper/__init__.py
+++ b/src/nexpy/examples/plugins/chopper/__init__.py
@@ -1,4 +1,4 @@
-from PySide import QtGui
+from matplotlib.backends.qt_compat import QtGui
 import get_ei, convert_qe
 
 def plugin_menu(parent):

--- a/src/nexpy/examples/plugins/chopper/convert_qe.py
+++ b/src/nexpy/examples/plugins/chopper/convert_qe.py
@@ -1,4 +1,4 @@
-from PySide import QtGui
+from matplotlib.backends.qt_compat import QtGui
 import numpy as np
 from nexpy.gui.datadialogs import BaseDialog
 from nexpy.gui.mainwindow import report_error

--- a/src/nexpy/examples/plugins/chopper/get_ei.py
+++ b/src/nexpy/examples/plugins/chopper/get_ei.py
@@ -1,4 +1,4 @@
-from PySide import QtGui
+from matplotlib.backends.qt_compat import QtGui
 import numpy as np
 from nexpy.gui.datadialogs import BaseDialog
 from nexpy.gui.mainwindow import report_error

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -42,7 +42,7 @@ import sys
 import tempfile
 
 # System library imports
-from PySide import QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtGui
 
 # Local imports
 from mainwindow import MainWindow

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 
-from PySide import QtGui, QtCore
+from matplotlib.backends.qt_compat import QtGui, QtCore
 import pkg_resources
 import numpy as np
 from scipy.optimize import minimize

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 
-from PySide import QtGui, QtCore
+from matplotlib.backends.qt_compat import QtGui, QtCore
 import pkg_resources
 import numpy as np
 

--- a/src/nexpy/gui/importdialog.py
+++ b/src/nexpy/gui/importdialog.py
@@ -14,7 +14,7 @@ Base class for import dialogs
 """
 
 import os
-from PySide import QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtGui
 
 from nexusformat.nexus import *
 from nexpy.gui.datadialogs import BaseDialog

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -30,7 +30,7 @@ import webbrowser
 import xml.etree.ElementTree as ET
 from threading import Thread
 
-from PySide import QtGui, QtCore
+from matplotlib.backends.qt_compat import QtGui, QtCore
 from IPython.core.magic import magic_escapes
 
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -15,7 +15,7 @@ Plotting window
 
 import pkg_resources
 import numpy as np
-from PySide import QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtGui
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib._pylab_helpers import Gcf

--- a/src/nexpy/gui/remotedialogs.py
+++ b/src/nexpy/gui/remotedialogs.py
@@ -12,7 +12,7 @@
 import logging
 import os
 
-from PySide import QtGui, QtCore
+from matplotlib.backends.qt_compat import QtGui, QtCore
 from Pyro4.errors import CommunicationError
 
 from nexusformat.nexus import (NeXusError, NXgroup, NXfield, NXattr,

--- a/src/nexpy/gui/scripteditor.py
+++ b/src/nexpy/gui/scripteditor.py
@@ -12,7 +12,7 @@
 import os
 import tempfile
 
-from PySide import QtGui
+from matplotlib.backends.qt_compat import QtGui
 import pygments
 from pygments.formatter import Formatter
 

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -11,7 +11,7 @@
 import os
 import pkg_resources
 
-from PySide import QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtGui
 from nexusformat.nexus import *
 
 

--- a/src/nexpy/nexpygui.py
+++ b/src/nexpy/nexpygui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #-----------------------------------------------------------------------------
@@ -11,12 +11,11 @@
 
 
 def main():
-
     # MUST define the QT_API before importing matplotlib
     import os, sys
-    os.environ['QT_API'] = 'pyside'
-    
+
     import matplotlib
+    matplotlib.rcParams['backend.qt4'] = 'PyQt4v2'
     matplotlib.use('Qt4Agg')
 
     sys.path.insert(0, os.path.abspath(os.path.join('..')))

--- a/src/nexpy/readers/readcbf.py
+++ b/src/nexpy/readers/readcbf.py
@@ -17,7 +17,7 @@ and its attributes and a single module, get_data, which returns an NXroot or NXe
 object. This will be added to the NeXpy tree.
 """
 
-from PySide import QtGui
+from matplotlib.backends.qt_compat import QtGui
 import numpy as np
 
 from nexusformat.nexus import *

--- a/src/nexpy/readers/readspec.py
+++ b/src/nexpy/readers/readspec.py
@@ -11,7 +11,7 @@
 
 '''Module to read in a SPEC file and convert it to NeXus.'''
 
-from PySide import QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtGui
 
 import numpy as np
 import os

--- a/src/nexpy/requires.py
+++ b/src/nexpy/requires.py
@@ -15,11 +15,9 @@ pkg_requirements = [
     'numpy>=1.6.0',
     'scipy',
     'h5py',
-    'matplotlib.backends.qt_compat>=1.1.0',
     'ipython>=1.1.0',
     'matplotlib>=1.2.0',
 ]
 extra_requirements = {
     'spec': ['spec2nexus>=2014.1228.0',],
 }
-

--- a/src/nexpy/requires.py
+++ b/src/nexpy/requires.py
@@ -15,7 +15,7 @@ pkg_requirements = [
     'numpy>=1.6.0',
     'scipy',
     'h5py',
-    'PySide>=1.1.0',
+    'matplotlib.backends.qt_compat>=1.1.0',
     'ipython>=1.1.0',
     'matplotlib>=1.2.0',
 ]


### PR DESCRIPTION
This uses matplotlib's qt compatibility layer to source the Qt classes.

It is a bit odd to use the plotting library to source the Qt layer, but
doing it this way will make sure that the main gui and matplotlib will
stay in sync back-end wise with out having to worry about import orders
and setting mpl rcParams.