### PR TITLE
Fix for PyQt5 compatibility issue

### DIFF
--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -1,8 +1,10 @@
+import matplotlib
 import sip
 for api in ['QString', 'QVariant']:
     sip.setapi(api, 2)
 
-from qtconsole.qt import QtCore, QtGui, QtSvg, QT_API
+matplotlib.use('Qt4Agg')
+from matplotlib.backends.qt_compat import QtCore, QtGui
 
 def getOpenFileName(*args, **kwargs):
     fname = QtGui.QFileDialog.getOpenFileName(*args, **kwargs)
@@ -15,4 +17,3 @@ def getSaveFileName(*args, **kwargs):
     if isinstance(fname, tuple):
         fname = fname[0]
     return fname
-

--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -3,7 +3,7 @@ import sip
 for api in ['QString', 'QVariant']:
     sip.setapi(api, 2)
 
-matplotlib.use('Qt4Agg')
+matplotlib.use('Qt4Agg', warn=False)
 from matplotlib.backends.qt_compat import QtCore, QtGui
 
 def getOpenFileName(*args, **kwargs):

--- a/src/nexpy/nexpygui.py
+++ b/src/nexpy/nexpygui.py
@@ -13,9 +13,6 @@
 def main():
     import os, sys
 
-    import matplotlib
-    matplotlib.use('Qt4Agg')
-
     sys.path.insert(0, os.path.abspath(os.path.join('..')))
     from nexpy.gui.consoleapp import main
     main()


### PR DESCRIPTION
I have switched to using the Matplotlib qt_compat module to import the
PyQt modules from the previous qtconsole-based method. This allows us to enforce the use of PyQt4 through matplotlib.use in a way that is
also compatible with qtconsole imports. This is a possible fix for #65.