### PR TITLE
 Enhance options for resetting limits

### DIFF
--- a/doc/source/pythongui.rst
+++ b/doc/source/pythongui.rst
@@ -276,11 +276,11 @@ Window Menu
     .. note:: This is equivalent to editing the values in the axis text boxes.
 
 **Reset Plot Limits**
-    This restores the axis limits to the original values. 
+    This restores the axis and signal limits to the original values.
 
-    .. note:: Clicking on the Home button in the Options Tab (see below) or 
-              right-clicking within the plot will also restore the original axis 
-              limits.
+    .. note:: This is equivalent to clicking on the Home button in the Options 
+              Tab (see below). Right-clicking within the plot restores the 
+              axis limits but does not reset the signal limits.
 
 **New Plot Window**
     Opens a new NeXpy plotting window, consisting of a Matplotlib plot pane and 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -174,12 +174,13 @@ class NXPlotView(QtGui.QDialog):
         def make_active(event):
             if 'Projection' not in self.label:
                 self.make_active()
-            if event.button == 1:
-                self.xdata = event.xdata
-                self.ydata = event.ydata
-            elif event.button == 3:
-                if hasattr(self, 'otab'):
+            self.xdata = event.xdata
+            self.ydata = event.ydata
+            if event.button == 3:
+                try:
                     self.otab.home(autoscale=False)
+                except Exception:
+                    pass
         cid = self.canvas.mpl_connect('button_press_event', make_active)
         self.canvas.figure.show = lambda *args: self.show()
         self.figuremanager._cidgcf = cid

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -179,7 +179,7 @@ class NXPlotView(QtGui.QDialog):
                 self.ydata = event.ydata
             elif event.button == 3:
                 hasattr(self, 'otab')
-                self.otab.home()
+                self.otab.home(autoscale=False)
         cid = self.canvas.mpl_connect('button_press_event', make_active)
         self.canvas.figure.show = lambda *args: self.show()
         self.figuremanager._cidgcf = cid
@@ -761,7 +761,7 @@ class NXPlotView(QtGui.QDialog):
             self.vaxis.max = vmax        
         self.update_tabs()
 
-    def reset_plot_limits(self):
+    def reset_plot_limits(self, autoscale=True):
         xmin, xmax, ymin, ymax = self.limits
         self.xaxis.min = self.xaxis.lo = self.xtab.minbox.old_value = xmin
         self.xaxis.max = self.xaxis.hi = self.xtab.maxbox.old_value = xmax
@@ -769,7 +769,7 @@ class NXPlotView(QtGui.QDialog):
         self.yaxis.max = self.yaxis.hi = self.ytab.maxbox.old_value = ymax
         if self.ndim == 1:
             self.replot_axes()
-        else:
+        elif autoscale:
             try:
                 self.vaxis.min = self.vaxis.lo = np.nanmin(self.v[self.v>-np.inf])
                 self.vaxis.max = self.vaxis.hi = np.nanmax(self.v[self.v<np.inf])
@@ -2372,9 +2372,9 @@ class NXNavigationToolbar(NavigationToolbar):
                                                 'resources/equal.png')))
         self._actions['set_aspect'].setCheckable(True)
 
-    def home(self, *args):
+    def home(self, autoscale=True):
         super(NXNavigationToolbar, self).home()        
-        self.plotview.reset_plot_limits()
+        self.plotview.reset_plot_limits(autoscale)
 
     def add_data(self):
         keep_data(self.plotview.plotdata)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -178,8 +178,8 @@ class NXPlotView(QtGui.QDialog):
                 self.xdata = event.xdata
                 self.ydata = event.ydata
             elif event.button == 3:
-                hasattr(self, 'otab')
-                self.otab.home(autoscale=False)
+                if hasattr(self, 'otab'):
+                    self.otab.home(autoscale=False)
         cid = self.canvas.mpl_connect('button_press_event', make_active)
         self.canvas.figure.show = lambda *args: self.show()
         self.figuremanager._cidgcf = cid


### PR DESCRIPTION
The default axis or signal limits, which can be changed through the sliders or text boxes, are reset by clicking on the Home button of the Options tab or invoking the “Reset Plot Limits” menu item. Previously, right-clicking within the plot had the same effect, but this has now been changed to reset the axes without changing the signal limits. This is often the preferred behavior, so this gives a quick method of enabling it.