### PR TITLE
Add the CXI file extension to the filter

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -181,7 +181,7 @@ class MainWindow(QtGui.QMainWindow):
         self.remote_defaults = (None, None)
 
         self.file_filter = ';;'.join((
-            "NeXus Files (*.nxs *.nx5 *.h5 *.hdf *.hdf5, *.cxi)",
+            "NeXus Files (*.nxs *.nx5 *.h5 *.hdf *.hdf5 *.cxi)",
             "Any Files (*.* *)"))
         self.max_recent_files = 20
 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -181,7 +181,7 @@ class MainWindow(QtGui.QMainWindow):
         self.remote_defaults = (None, None)
 
         self.file_filter = ';;'.join((
-            "NeXus Files (*.nxs *.nx5 *.h5 *.hdf *.hdf5)",
+            "NeXus Files (*.nxs *.nx5 *.h5 *.hdf *.hdf5, *.cxi)",
             "Any Files (*.* *)"))
         self.max_recent_files = 20
 


### PR DESCRIPTION
A minor change to make files stored in the CXI format, an HDF5 format derived from NeXus, available by default.