### PR TITLE
Skew axes

### DIFF
--- a/doc/source/pythongui.rst
+++ b/doc/source/pythongui.rst
@@ -491,7 +491,10 @@ and sliders.
     * **Save** - saves plot to PNG file.
     * **Add** - adds plotted data to the tree pane as an NXdata group within the
       scratch workspace 'w0'.
-    * **Edit** - allows marker and line formatting to be modified.
+    * **Edit** - opens dialog to customize both image and point plots. Use this
+      to change the title and axis labels, modify the image aspect ratio and 
+      skew angles, turn axis grids on or off, or modify the point plot markers 
+      and lines.
 
     On the far right of the toolbar, the data and axis values are dynamically 
     updated to the values under the current mouse location.
@@ -526,6 +529,16 @@ and sliders.
   function, *i.e.*, 'auto', 'equal', or the numerical value of the 
   ratio between the height and the width (if the units are identical). The 
   'Aspect' button (see above) toggles between 'auto' and 'equal'.
+
+* Set Skew Angle::
+
+    >>> plotview.skew = <angle>
+
+  This sets the angle between the x and y-axes in degrees. If set to ``None``,
+  the axes are plotted as orthogonal. If ``plotview.aspect`` is currently set to 
+  'auto', this command will automatically set it to 1.0 (equivalent to 'equal'),
+  *i.e.*, assuming the units of the x and y-axes are the same. If they are not, 
+  ``plotview.aspect`` should be set to the ratio of their units.
 
 * Set Offsets::
 
@@ -572,6 +585,15 @@ and sliders.
   properties, *etc*. See the `Matplotlib documentation 
   <http://matplotlib.org/api/patches_api.html#matplotlib.patches.Polygon>`_
   for more details.
+
+* Draw Grid:
+
+    >>> plotview.grid(True|False)
+
+  Draws grid lines at the major tick values. Additional keyword arguments can be
+  given to modify the color, linestyle, *etc*, using the standard `Matplotlib 
+  conventions 
+  <http://matplotlib.org/api/axes_api.html?highlight=grid#matplotlib.axes.Axes.grid>`_.
 
 Fitting NeXus Data
 ------------------

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 
-from nexpy.gui.pyqt import QtGui, QtCore, getOpenFileName
+from .pyqt import QtGui, QtCore, getOpenFileName
 import pkg_resources
 import numpy as np
 from scipy.optimize import minimize
@@ -204,6 +204,20 @@ class BaseDialog(QtGui.QDialog):
         from glob import glob
         filenames = glob(prefix+'*'+extension)
         return sorted(filenames,key=natural_sort)
+
+    def select_box(self, choices, default=None, slot=None):
+        box = QtGui.QComboBox()
+        box.setSizeAdjustPolicy(QtGui.QComboBox.AdjustToContents)
+        for choice in choices:
+            box.addItem(choice)
+        if default in choices:
+            idx = box.findText(default)
+            box.setCurrentIndex(idx)
+        else:
+            box.setCurrentIndex(0)
+        if slot:
+            box.currentIndexChanged.connect(slot)
+        return box
 
     def select_root(self, slot=None, text='Select Root :', other=False):
         layout = QtGui.QHBoxLayout()

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -427,6 +427,7 @@ class GridParameters(OrderedDict):
             fit_label = QtGui.QLabel('Fit?')
             fit_label.setFont(header_font)
             grid.addWidget(fit_label, 0, 2, QtCore.Qt.AlignHCenter)
+        self.grid_layout = grid
         return grid
 
     def set_parameters(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -29,6 +29,8 @@ from matplotlib.colors import LogNorm, Normalize
 from matplotlib.cm import cmap_d, get_cmap
 from matplotlib.patches import Circle, Ellipse, Rectangle
 from matplotlib.transforms import nonsingular
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
+from mpl_toolkits.axisartist import Subplot
 
 from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError
 
@@ -104,9 +106,6 @@ class NXCanvas(FigureCanvas):
 
     def __init__(self, figure):
 
-        self.axes = figure.add_subplot(111)
-        self.axes.hold(False)
-
         FigureCanvas.__init__(self, figure)
 
         FigureCanvas.setSizePolicy(self,
@@ -119,7 +118,6 @@ class NXFigureManager(FigureManager):
 
     def __init__(self, canvas, num):
         FigureManagerBase.__init__(self, canvas, num)
-        self.canvas = canvas
 
         def notify_axes_change(fig):
             # This will be called whenever the current axes is changed
@@ -193,6 +191,10 @@ class NXPlotView(QtGui.QDialog):
             self.figure.set_label(self.label)
         else:
             self.label = "Figure %d" % self.number
+
+        self._skew_angle = None
+        self.grid_helper = GridHelperCurveLinear((self.transform, 
+                                                  self.inverse_transform))
         
         vbox = QtGui.QVBoxLayout()
         vbox.addWidget(self.canvas)
@@ -555,8 +557,6 @@ class NXPlotView(QtGui.QDialog):
     def plot_image(self, over=False, **opts):
 
         mpl.interactive(False)
-        if not over: 
-            self.figure.clf()
 
         self.x, self.y, self.v = self.get_image()
 
@@ -567,7 +567,9 @@ class NXPlotView(QtGui.QDialog):
         else:
             opts["norm"] = Normalize(self.vaxis.lo, self.vaxis.hi)
 
-        ax = self.figure.gca()
+        self.figure.clf()
+        subplot = Subplot(self.figure, 1, 1, 1, grid_helper=self.grid_helper)
+        ax = self.figure.add_subplot(subplot)
         ax.autoscale(enable=True)
         ax.format_coord = self.format_coord
 
@@ -584,15 +586,17 @@ class NXPlotView(QtGui.QDialog):
         if 'aspect' in opts:
             self.aspect = opts['aspect']
             del opts['aspect']
-        if self.rgb_image or self.equally_spaced:
+        if (self.rgb_image or self.equally_spaced) and self.skew is None:
             opts['origin'] = 'lower'
             if 'interpolation' not in opts:
                 opts['interpolation'] = 'nearest'
             self.image = ax.imshow(self.v, extent=extent, cmap=self.cmap, 
                                    **opts)
         else:
-            self.image = ax.pcolormesh(self.x, self.y, self.v, cmap=self.cmap, 
-                                       **opts)
+            if self.skew is not None:
+                yy, xx = np.meshgrid(self.y, self.x)
+                x, y = self.transform(xx, yy)
+            self.image = ax.pcolormesh(x, y, self.v, cmap=self.cmap, **opts)
         self.image.get_cmap().set_bad('k', 1.0)
         ax.set_aspect(self.aspect)
         
@@ -725,6 +729,22 @@ class NXPlotView(QtGui.QDialog):
         if draw:
             self.draw()
 
+    def transform(self, x, y):
+        if self.skew is None:
+            return x, y
+        else:    
+            x, y = np.asarray(x), np.asarray(y)
+            angle = np.radians(self.skew)
+            return 1.*x+np.cos(angle)*y,  np.sin(angle)*y
+
+    def inverse_transform(self, x, y):
+        if self.skew is None:
+            return x, y
+        else:
+            x, y = np.asarray(x), np.asarray(y)
+            angle = np.radians(self.skew)
+            return 1.*x-y/np.tan(angle),  y/np.sin(angle)
+
     def set_log_image(self):
         if self.vtab.logbox.isChecked():
             self.set_data_limits()
@@ -799,6 +819,21 @@ class NXPlotView(QtGui.QDialog):
             pass
 
     aspect = property(_aspect, _set_aspect, "Property: Aspect ratio value")
+
+    def _skew(self):
+        return self._skew_angle
+        
+    def _set_skew(self, skew_angle):
+        if skew_angle is None or (np.isclose(skew_angle, 0.0) or 
+                                  np.isclose(skew_angle, 90.0)):
+            self._skew_angle = None
+        else:
+            self._skew_angle = skew_angle
+        self.aspect = "equal"
+        self.grid_helper = GridHelperCurveLinear((self.transform, 
+                                                  self.inverse_transform))
+
+    skew = property(_skew, _set_skew, "Property: Axis skew angle")
 
     def _autoscale(self):
         if self.ndim > 2 and self.ztab.scalebox.isChecked():

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -36,6 +36,7 @@ from matplotlib.patches import Circle, Ellipse, Rectangle, Polygon
 from matplotlib.transforms import nonsingular
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 from mpl_toolkits.axisartist import Subplot
+from mpl_toolkits.axisartist.grid_finder import MaxNLocator
 
 from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError
 
@@ -58,6 +59,7 @@ interpolations = ['nearest', 'bilinear', 'bicubic', 'spline16', 'spline36',
 linestyles = {'-': 'Solid', '--': 'Dashed', '-.': 'DashDot', ':': 'Dotted',
               'none': 'None', 'None': 'None'}
 markers = markers.MarkerStyle.markers
+locator = MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True)
 
 
 def report_error(context, error):
@@ -202,7 +204,9 @@ class NXPlotView(QtGui.QDialog):
 
         self._skew_angle = None
         self.grid_helper = GridHelperCurveLinear((self.transform, 
-                                                  self.inverse_transform))
+                                                  self.inverse_transform),
+                                                  grid_locator1=locator,
+                                                  grid_locator2=locator)
         
         vbox = QtGui.QVBoxLayout()
         vbox.addWidget(self.canvas)
@@ -844,7 +848,9 @@ class NXPlotView(QtGui.QDialog):
         if self.skew is not None and self.aspect == 'auto':
             self.aspect = 'equal'
         self.grid_helper = GridHelperCurveLinear((self.transform, 
-                                                  self.inverse_transform))
+                                                  self.inverse_transform),
+                                                  grid_locator1=locator,
+                                                  grid_locator2=locator)
         if self.image is not None:
             self.replot_data(newaxis=True)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -224,6 +224,7 @@ class NXPlotView(QtGui.QDialog):
         self.xaxis = self.yaxis = self.zaxis = None
         self.xmin = self.xmax = self.ymin = self.ymax = self.vmin = self.vmax = None
 
+        self.image = None
         self.colorbar = None
         self.zoom = None
         self.aspect = 'auto'
@@ -555,6 +556,7 @@ class NXPlotView(QtGui.QDialog):
             self.xaxis.lo, self.xaxis.hi = self.xaxis.min, self.xaxis.max
             self.yaxis.lo, self.yaxis.hi = self.yaxis.min, self.yaxis.max
 
+        self.image = None
         self.colorbar = None
 
     def get_image(self):
@@ -830,6 +832,8 @@ class NXPlotView(QtGui.QDialog):
             self.aspect = "equal"
         self.grid_helper = GridHelperCurveLinear((self.transform, 
                                                   self.inverse_transform))
+        if self.image is not None:
+            self.replot_data(newaxis=True)
 
     skew = property(_skew, _set_skew, "Property: Axis skew angle")
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -897,6 +897,12 @@ class NXPlotView(QtGui.QDialog):
     def draw(self):
         self.canvas.draw_idle()
 
+    def grid(self, display=True, **opts):
+        if 'color' not in opts:
+            opts['color'] = 'w'
+        self.ax.grid(display, **opts)
+        self.draw()
+
     def vline(self, x, ymin=None, ymax=None, **opts):
         ylo, yhi = self.yaxis.get_limits()
         if ymin is None:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -596,6 +596,8 @@ class NXPlotView(QtGui.QDialog):
             if self.skew is not None:
                 yy, xx = np.meshgrid(self.y, self.x)
                 x, y = self.transform(xx, yy)
+            else:
+                x, y = self.x, self.y
             self.image = ax.pcolormesh(x, y, self.v, cmap=self.cmap, **opts)
         self.image.get_cmap().set_bad('k', 1.0)
         ax.set_aspect(self.aspect)


### PR DESCRIPTION
Adds the option to plot non-orthogonal axes, setting the skew angle and aspect ratios from a new Customize Plot dialog or from the command line. This is particularly useful for plotting reciprocal space data, stored in an (h,k,l) grid, when the reciprocal lattice axes are not orthogonal.