### PR TITLE
Update values for lmfit version > 0.8.3

### DIFF
--- a/src/nexpy/api/frills/fit.py
+++ b/src/nexpy/api/frills/fit.py
@@ -52,6 +52,9 @@ class Fit(object):
         return model
 
     def residuals(self, parameters):
+        if __version__ > '0.8.3':
+            for parameter in parameters:
+                self.parameters[parameter].value = parameters[parameter].value
         if self.e is not None:
              return (self.y - self.get_model()) / self.e
         else:
@@ -67,11 +70,11 @@ class Fit(object):
                 if p.value is None:
                     p.value = 1.0
         self.result = minimize(self.residuals, self.parameters)
+        if __version__ > '0.8.3':
+            for parameter in self.parameters:
+                self.parameters[parameter].value = self.result.params[parameter].value
         for f in self.functions:
             for p in f.parameters:
-                if __version__ > '0.8.3':
-                    p.init_value = p.value
-                    p.value = self.result.params[p.name].value
                 p.name = p.original_name
 
     def fit_report(self):

--- a/src/nexpy/api/frills/fit.py
+++ b/src/nexpy/api/frills/fit.py
@@ -10,7 +10,7 @@
 #-----------------------------------------------------------------------------
 
 import numpy as np
-from lmfit import minimize, Parameters, Parameter, fit_report
+from lmfit import minimize, Parameters, Parameter, fit_report, __version__
 
 from nexusformat.nexus import NXdata, NXparameters, NeXusError
 
@@ -69,6 +69,9 @@ class Fit(object):
         self.result = minimize(self.residuals, self.parameters)
         for f in self.functions:
             for p in f.parameters:
+                if __version__ > '0.8.3':
+                    p.init_value = p.value
+                    p.value = self.result.params[p.name].value
                 p.name = p.original_name
 
     def fit_report(self):

--- a/src/nexpy/api/frills/fit.py
+++ b/src/nexpy/api/frills/fit.py
@@ -69,10 +69,12 @@ class Fit(object):
                 self.parameters[f.name+p.name] = p
                 if p.value is None:
                     p.value = 1.0
+                p.init_value = p.value
         self.result = minimize(self.residuals, self.parameters)
         if __version__ > '0.8.3':
             for parameter in self.parameters:
-                self.parameters[parameter].value = self.result.params[parameter].value
+                self.parameters[parameter].value = \
+                    self.result.params[parameter].value
         for f in self.functions:
             for p in f.parameters:
                 p.name = p.original_name


### PR DESCRIPTION
The current version of NeXpy is not compatible with lmfit v0.9, which no longer updates the input parameters in place, but puts the fit results into a new MinmizerResult object. This pull request is not ready to merge yet, because my initial tests do not show any change in the MinimizerResult parameters. So this may fix one of the problems, but it might just hide other problems. I am issuing the request to make others aware of the branch, which is related to issue #73.