### PR TITLE
Fix axis tick positions

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -753,6 +753,13 @@ class NXPlotView(QtGui.QDialog):
             angle = np.radians(self.skew)
             return 1.*x-y/np.tan(angle),  y/np.sin(angle)
 
+    def locator(self, *args, **opts):
+        locator = MaxNLocator(*args, **opts)
+        self.grid_helper = GridHelperCurveLinear((self.transform, 
+                                                  self.inverse_transform),
+                                                  grid_locator1=locator,
+                                                  grid_locator2=locator)
+
     def set_log_image(self):
         if self.vtab.logbox.isChecked():
             self.set_data_limits()

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -59,7 +59,7 @@ interpolations = ['nearest', 'bilinear', 'bicubic', 'spline16', 'spline36',
 linestyles = {'-': 'Solid', '--': 'Dashed', '-.': 'DashDot', ':': 'Dotted',
               'none': 'None', 'None': 'None'}
 markers = markers.MarkerStyle.markers
-locator = MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True)
+locator = MaxNLocator(nbins=9, steps=[1, 2, 5, 10])
 
 
 def report_error(context, error):


### PR DESCRIPTION
In adding skew axes, the ‘integer’ keyword argument to MaxNLocator was set to True. This has the unfortunate consequence of selecting only integers for major ticks (see issue #81), so it is being removed.