### PR TITLE
Rhel core dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ or
     $ easy_install nexpy 
 ```
 
+If you have an Anaconda installation, use::
+
+```
+    $ conda install -c nexpy nexpy
+```
+
 The source code can be downloaded from the NeXpy Git repository:
 
 ```
@@ -39,46 +45,105 @@ To install in an alternate location:
     $ python setup.py install --prefix=/path/to/installation/dir
 ```
 
+As of v0.6.0, the Python API for reading and writing NeXus files is in a 
+separate package, [nexusformat](https://github.com/nexpy/nexusformat), which 
+is also available on [PyPI](https://pypi.python.org/pypi/nexusformat/) and 
+will be automatically installed as a NeXpy dependency if you use pip. 
+
+If the NeXpy GUI is not required, the package may be used in a regular Python
+shell. It may be installed using:: 
+
+```
+    $ pip install nexusformat
+```
+
+or:: 
+
+```
+    $ easy_install nexusformat 
+```
+
+or::
+
+```
+    $ conda install -c nexpy nexusformat
+```
+
+The package can also be installed from the source code using the setup commands
+described above. The source code is available either by downloading one of the 
+[Github releases](https://github.com/nexpy/nexusformat/releases>) or by cloning 
+the latest development version in the 
+[NeXpy Git repository](https://github.com/nexpy/nexusformat>)::
+
+```
+    $ git clone https://github.com/nexpy/nexusformat.git
+```
+
 Prerequisites
 =============
-The following libraries are used by the full installation of NeXpy. There is 
-more details of the nature of these dependencies in the 
-[NeXpy documentation](http://nexpy.github.io/nexpy).
+Python Command-Line API
+-----------------------
+The current version of NeXpy uses h5py to read and write NeXus files because
+of its ability to handle large data files. There is therefore no dependency 
+on the [NeXus C API](http://download.nexusformat.org/doc/html/napi.html). 
+This also means that the current version cannot read and write HDF4 or XML 
+NeXus files.
 
-* h5py                 http://www.h5py.org
-* numpy,scipy          http://numpy.scipy.org
-* jupyter              http://jupyter.org
-* IPython v4.0.0       http://ipython.org
-* matplotlib v1.4.0    http://matplotlib.sourceforge.net
-* lmfit                http://newville.github.io/lmfit-py (Fitting only)
-* pycbf                http://www.bernstein-plus-sons.com/software/CBF/ (CBF reader only)
-* spec2nexus           http://spec2nexus.readthedocs.org (SPEC reader only)
+If you only intend to utilize the Python API from the command-line, the only 
+other required library is [Numpy](http://numpy.scipy.org).
 
+* [nexusformat](https://github.com/nexpy/nexusformat)
+* [h5py](http://www.h5py.org)
+* [numpy](http://numpy.scipy.org/)
+
+NeXpy GUI
+---------
 The GUI is built using the PyQt. The latest version supports either 
 PyQt4 or PySide, and should load whichever library it finds. Neither are 
 listed as a dependency but one or other must be installed. PyQt4 is included
 in the 
 [Anaconda default distribution](https://store.continuum.io/cshop/anaconda/) 
 while PySide is included in the 
-[Enthought Python Distribution](http://www.enthought.com>) or within Enthought's 
-[Canopy Application](https://www.enthought.com/products/canopy/>).
+[Enthought Python Distribution](http://www.enthought.com) or within Enthought's 
+[Canopy Application](https://www.enthought.com/products/canopy/).
 
-The following environment variable may need to be set
-PYTHONPATH --> paths to ipython,numpy,scipy,matplotlib if installed in a 
-nonstandard place
+The GUI includes an [IPython shell](http://ipython.org/) and a 
+[Matplotlib plotting pane](http://matplotlib.sourceforge.net). The IPython shell 
+is embedded in the Qt GUI using an implementation based on the newly-released
+Jupyter QtConsole, which has replaced the old IPython QtConsole.
+          
+* [jupyter](http://jupyter.org/)
+* [IPython v4.0.0](http://ipython.org/)
+* [matplotlib v1.4.0](http://matplotlib.sourceforge.net/)
 
-PySide 1.1.0 on rpm systems
----------------------------
+Some people have reported that NeXpy crashes on launch on some Linux systems.
+We believe that this may be due to both PyQt4 and PyQt5 being installed,
+although that doesn't cause a problem on all systems. If NeXpy crashes on
+launch, please try setting the environment variable QT_API to either 'pyqt',
+for the PyQt4 library, or 'pyside', for the PySide library, depending on what
+you have installed, e.g., in BASH, type ::
 
-python-pyside v1.1.0 rpm has a bug in it where it does not supply the egg-info
-that dist-utils looks for. There is a workaround mentioned in
-https://github.com/nvbn/everpad/issues/401#issuecomment-35834335 which is to
-spoof the system with a fake file in
-`/usr/lib/python2.7/dist-packages/PySide-1.1.0-py2.7.egg-info`
-or
-`/usr/lib/python2.7/site-packages/PySide-1.1.0-py2.7.egg-info`
-depending on which install location exists. It appears that v1.2.0 contains
-the missing file.
+```
+    $ export QT_API=pyqt
+```
+Additional Packages
+-------------------
+Additional functionality is provided by other external Python packages. 
+Least-squares fitting requires Matt Newville's least-squares fitting package, 
+[lmfit-py](http://newville.github.io/lmfit-py). Importers may also require 
+libraries to read the imported files in their native format, e.g., 
+[spec2nexus](http://spec2nexus.readthedocs.org/) for reading SPEC files. 
+
+From v0.4.3, the log window is colorized if 
+[ansi2html](https://pypi.python.org/pypi/ansi2html/) is installed.
+
+The following packages are recommended.
+
+* Least-squares fitting: [lmfit](http://newville.github.io/lmfit-py/)
+* TIFF file imports: [tifffile](https://pypi.python.org/pypi/tifffile)
+* CBF file imports: [pycbf](http://sourceforge.net/projects/cbflib/files/cbflib/pycbf/)
+* SPEC file imports: [spec2nexus](http://spec2nexus.readthedocs.org/)
+* Log file colorization: [ansi2html](https://pypi.python.org/pypi/ansi2html/)
 
 To run with the GUI
 ===================
@@ -87,7 +152,7 @@ To run from the installed location, add the $prefix/bin directory to your path
 (only if you installed outside the python installation), and then run:
 
 ```
-nexpy
+    $ nexpy
 ```
 
 User Support

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,16 @@ IPython v4.0.0     http://ipython.org/
 matplotlib v1.4.0  http://matplotlib.sourceforge.net/
 =================  =================================================
 
+.. warning:: Some people have reported that NeXpy crashes on launch on some
+             Linux systems. We believe that this may be due to both PyQt4 and
+             PyQt5 being installed, although that doesn't cause a problem on 
+             all systems. If NeXpy crashes on launch, please try setting the
+             environment variable QT_API to either 'pyqt', for the PyQt4 
+             library, or 'pyside', for the PySide library, depending on what you
+             have installed, *e.g.*, in BASH, type ::
+
+                 export QT_API=pyqt
+
 .. seealso:: If you are having problems linking to the PySide library, you may
              need to run the PySide post-installation script after installing
              PySide, *i.e.*, ``python pyside_postinstall.py -install``. See 

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -39,8 +39,6 @@ from traitlets.config.application import catch_config_error
 from qtconsole.jupyter_widget import JupyterWidget
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole import styles, __version__
-from qtconsole.client import QtKernelClient
-from qtconsole.manager import QtKernelManager
 from traitlets import (
     Dict, Unicode, CBool, Any
 )
@@ -129,8 +127,6 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
     aliases = Dict(aliases)
     frontend_flags = Any(qt_flags)
     frontend_aliases = Any(qt_aliases)
-    kernel_client_class = QtKernelClient
-    kernel_manager_class = QtKernelManager
 
     stylesheet = Unicode('', config=True,
         help="path to a custom CSS stylesheet")

--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -1,7 +1,8 @@
 import os
 import matplotlib
 import sip
-for api in ['QString', 'QVariant']:
+for api in ['QString', 'QVariant', 'QDate', 'QDateTime', 'QTextStream', 'QTime', 
+            'QUrl']:
     sip.setapi(api, 2)
 
 matplotlib.use('Qt4Agg', warn=False)

--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -1,3 +1,4 @@
+import os
 import matplotlib
 import sip
 for api in ['QString', 'QVariant']:
@@ -5,6 +6,10 @@ for api in ['QString', 'QVariant']:
 
 matplotlib.use('Qt4Agg', warn=False)
 from matplotlib.backends.qt_compat import QtCore, QtGui
+if QtCore.__name__.lower().startswith('pyqt4'):
+    os.environ['QT_API'] = 'pyqt'
+elif QtCore.__name__.lower().startswith('pyside'):
+    os.environ['QT_API'] = 'pyside'
 
 def getOpenFileName(*args, **kwargs):
     fname = QtGui.QFileDialog.getOpenFileName(*args, **kwargs)


### PR DESCRIPTION
Apart from a few extraneous documentation updates, this PR does two things: 1) removes a couple of Jupyter unneeded imports that cause zmq to be imported, and 2) sets the QT_API environment variable after the version of PyQt has been selected by matplotlib.backends.qt_compat. The latter should coerce Jupyter into using the same PyQt versions in qtconsole.qt.