### PR TITLE
Normalize projections

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexpy
-  version: "0.8.0"
+  version: "0.8.1"
 
 source:
   git_url: https://github.com/nexpy/nexpy.git
-  git_tag: v0.8.0
+  git_tag: v0.8.1
 
 build:
   entry_points:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,7 +16,7 @@ knowledge of the file format. The underlying Python API for reading and writing
 NeXus files is provided by the `nexusformat 
 <https://github.com/nexpy/nexusformat>`_ package, which is also described here.
 
-.. note:: NeXpy v0.8.0 is now available for `download 
+.. note:: NeXpy v0.8.1 is now available for `download 
           <https://pypi.python.org/pypi/NeXpy/>`_ (`Release Notes 
           <https://github.com/nexpy/nexpy/releases>`_). This is a beta-release 
           so please post any issues that you encounter on the `NeXpy GitHub 

--- a/doc/source/pythongui.rst
+++ b/doc/source/pythongui.rst
@@ -401,10 +401,14 @@ and sliders.
 
     If the data rank is three or more, the 2D plot *vs* x and y is a projection 
     along the remaining axes. The z-tab sets the limits for those projections.
-    It contains a dropdown menu for selecting the axis to be summed over and
-    two text boxes for selecting the projection limits. When the data are first
-    plotted, only the top slice if plotted, *i.e.*, all the z-axis limits are 
-    set to their minimum value.
+    It contains a dropdown menu for selecting the axis to be averaged or summed 
+    over and two text boxes for selecting the projection limits. When the data 
+    are first plotted, only the top slice if plotted, *i.e.*, all the z-axis 
+    limits are set to their minimum value.
+
+    .. note:: Projections are now averaged over the summed bins by default. To
+              restore the previous behavior, click the 'Sum' checkbox in the
+              Projection Tab.
     
     When 'Lock' is checked, the difference between the limits of the selected 
     z-axis is fixed. This allows successive images along the z-axis to be 
@@ -454,6 +458,9 @@ and sliders.
        :align: center
        :width: 75%
 
+    .. note:: Projections are now averaged over the summed bins by default. To
+              restore the previous behavior, click the 'Sum' checkbox.
+    
     The projection tab also contains a button to open a separate projection 
     panel. The panel is more convenient when making a systematic exploration of 
     different projections limits and provides pixel accuracy in computing 

--- a/doc/source/pythonshell.rst
+++ b/doc/source/pythonshell.rst
@@ -731,6 +731,18 @@ NXdata.sum(axis=None):
      >>> a.sum(1).nxsignal
      NXfield([  0.   6.  12.])   
 
+NXdata.average(axis=None):
+    Returns the average of the NXdata signal data. This is identical to the sum
+    method, but the result is divided by the number of data elements in the 
+    summation::
+
+     >>> a.average()
+     1.5
+     >>> a.average(0).nxsignal
+     NXfield([ 0.,  1.,  2.,  3.])
+     >>> a.average(1).nxsignal
+     NXfield([ 0. ,  1.5,  3. ])   
+
 NXdata.moment(order=1):
     Returns an NXfield containing the first moment of the NXdata group assuming 
     the signal is one-dimensional. Currently, only the first moment has been 


### PR DESCRIPTION
Gives the option of viewing projections as an average over the summed bins. The original behavior, *i.e.*, summing over the bins, can be restored using the 'Sum' checkbox on the Projection Tab or in the Projection Panel.