### PR TITLE
Need to define a default parent for BaseDialog instances

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -54,6 +54,8 @@ class BaseDialog(QtGui.QDialog):
         self.checkbox = {}
         self.radiobutton = {}
         self.confirm_action, self.report_error = confirm_action, report_error
+        if parent is None:
+            parent = self.mainwindow
         super(BaseDialog, self).__init__(parent)
 
     def set_layout(self, *items):


### PR DESCRIPTION
I’m not sure why this was removed, but windows will disappear without
it, unless displayed as modal dialogs.