### PR TITLE
Enable saving and purging of a scratch file

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -34,7 +34,7 @@ from .mainwindow import MainWindow
 from .treeview import NXtree
 from .utils import NXConfigParser, timestamp_age
 
-from nexusformat.nexus import nxclasses, nxload
+from nexusformat.nexus import NXroot, nxclasses, nxload
 
 from traitlets.config.application import boolean_flag
 from traitlets.config.application import catch_config_error
@@ -179,6 +179,9 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         self.reader_dir = os.path.join(self.nexpy_dir, 'readers')
         self.script_dir = os.path.join(self.nexpy_dir, 'scripts')
         self.function_dir = os.path.join(self.nexpy_dir, 'functions')
+        self.scratch_file = os.path.join(self.nexpy_dir, 'w0.nxs')
+        if not os.path.exists(self.scratch_file):
+            NXroot().save(self.scratch_file)
 
     def init_settings(self):
         self.settings = NXConfigParser(os.path.join(self.nexpy_dir, 

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -22,7 +22,7 @@ import pkg_resources
 import numpy as np
 
 from nexusformat.nexus import (NeXusError, NXgroup, NXfield, NXattr,
-                               NXroot, NXentry, NXdata, NXparameters)
+                               NXroot, NXentry, NXdata, NXparameters, nxload)
 from .datadialogs import BaseDialog
 from .plotview import NXPlotView
 from .utils import report_error
@@ -516,7 +516,7 @@ class FitDialog(BaseDialog):
             entry['title'] = 'Fit Model'
             entry['model'] = self.get_model()
         if 'w0' not in self.tree:
-            self.tree.add(NXroot(name='w0'))
+            self.tree['w0'] = nxload(self.mainwindow.scratch_file, 'rw')
         ind = []
         for key in self.tree['w0']:
             try:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -43,7 +43,7 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinea
 from mpl_toolkits.axisartist import Subplot
 from mpl_toolkits.axisartist.grid_finder import MaxNLocator
 
-from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError
+from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError, nxload
 
 from .. import __version__
 from .datadialogs import BaseDialog, GridParameters
@@ -2948,9 +2948,9 @@ class NXColorButton(ColorButton):
 
 
 def keep_data(data):
-    from .consoleapp import _tree
+    from .consoleapp import _nexpy_dir, _tree
     if 'w0' not in _tree:
-        _tree.add(NXroot(name='w0'))
+        _tree['w0'] = nxload(os.path.join(_nexpy_dir, 'w0.nxs'), 'rw')
     ind = []
     for key in _tree['w0']:
         try:

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -23,14 +23,22 @@ def report_error(context, error):
     return message_box.exec_()
 
 
-def confirm_action(query, information=None):
+def confirm_action(query, information=None, answer=None):
     """Display a message box requesting confirmation"""
     message_box = QtGui.QMessageBox()
     message_box.setText(query)
     if information:
         message_box.setInformativeText(information)
-    message_box.setStandardButtons(QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel)
-    message_box.setDefaultButton(QtGui.QMessageBox.Ok)
+    if answer == 'yes' or answer == 'no':
+        message_box.setStandardButtons(QtGui.QMessageBox.Yes | 
+                                       QtGui.QMessageBox.No)
+        if answer == 'yes':                           
+            message_box.setDefaultButton(QtGui.QMessageBox.Yes)
+        else:
+            message_box.setDefaultButton(QtGui.QMessageBox.No)
+    else:
+        message_box.setStandardButtons(QtGui.QMessageBox.Ok | 
+                                       QtGui.QMessageBox.Cancel)
     return message_box.exec_()
 
 


### PR DESCRIPTION
NeXpy has used `w0` as a scratch area for saving projections and fit results. These changes automatically create 'w0.nxs' in the users ~/.nexpy directory, which will then be opened automatically when `w0` is invoked. New File Menu items allow the opening, purging, and closing of this file.