### PR TITLE
Make NXConfigParser Windows-compatible

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3408,8 +3408,11 @@ class NXNavigationToolbar(NavigationToolbar):
         self.plotview.reset_plot_limits(autoscale)
 
     def edit_parameters(self):
-        self.plotview.customize_panel = CustomizeDialog(parent=self.plotview)
-        self.plotview.customize_panel.show()
+        if self.plotview.customize_panel is None:
+            self.plotview.customize_panel = CustomizeDialog(parent=self.plotview)
+            self.plotview.customize_panel.show()
+        else:
+            self.plotview.customize_panel.raise_()
 
     def add_data(self):
         keep_data(self.plotview.plotdata)

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -119,22 +119,11 @@ def is_timestamp(time_string):
 class NXConfigParser(ConfigParser, object):
     """A ConfigParser subclass that preserves the case of option names"""
 
-    _OPT_NV_TMPL = r"""
-        (?P<option>.*?)                    # very permissive!
-        \s*(?:                             # any number of space/tab,
-        (?P<vi>{delim})\s*                 # optionally followed by
-                                           # any of the allowed
-                                           # delimiters, followed by any
-                                           # space/tab
-        (?P<value>.*))?$                   # everything up to eol
-        """
-
     def __init__(self, settings_file):
         super(NXConfigParser, self).__init__(allow_no_value=True)
         self.file = settings_file
-        d = "|".join(re.escape(d) for d in ['{','}'])
-        self._optcre = re.compile(self._OPT_NV_TMPL.format(delim=d),
-                                  re.VERBOSE)
+        self._optcre = re.compile(
+            r"(?P<option>.*?)\s*(?:(?P<vi>=)\s*(?P<value>.*))?$", re.VERBOSE)
         super(NXConfigParser, self).read(self.file)
         sections = self.sections()
         if 'recent' not in sections:

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -122,7 +122,7 @@ class NXConfigParser(ConfigParser, object):
     def __init__(self, settings_file):
         super(NXConfigParser, self).__init__(allow_no_value=True)
         self.file = settings_file
-        self._optcre = re.compile(
+        self._optcre = re.compile( #makes '=' the only valid key/value delimiter
             r"(?P<option>.*?)\s*(?:(?P<vi>=)\s*(?P<value>.*))?$", re.VERBOSE)
         super(NXConfigParser, self).read(self.file)
         sections = self.sections()


### PR DESCRIPTION
At the moment, if there is ‘C:’ at the start of a file path, the ‘C’ is interpreted as a settings key. This backports a regular expression that removes ‘:’ as a key/value delimiter.