### PR TITLE
Update API from nexusformat package

### DIFF
--- a/src/nexpy/api/nexus/__init__.py
+++ b/src/nexpy/api/nexus/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2015, NeXpy Development Team.
+# Copyright (c) 2014, NeXpy Development Team.
 #
 # Author: Paul Kienzle, Ray Osborn
 #
@@ -51,5 +51,20 @@ We can create a copy of the file using write::
 For a complete description of the features available in this tree view
 of the NeXus data file, see `nexus.tree`.
 
+NeXus API
+=========
+
+When converting code to python from other languages you do not
+necessarily want to rewrite the file handling code using the
+tree view.  The `nexus.napi` module provides an interface which
+more closely follows the NeXus application programming
+interface (NAPI_).
+
+.. _Nexus: http://www.nexusformat.org/Introduction
+.. _NAPI:  http://www.nexusformat.org/Application_Program_Interface
+.. _HDF:   http://www.hdfgroup.org
 """
-from nexusformat.nexus.tree import *
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .tree import *


### PR DESCRIPTION
The NeXus API within the NeXpy source code tree is not currently used because it is now imported through the nexusformat package, but it is kept for legacy reasons. This update should prevent some problems with syntax checkers, for example, when creating conda packages.