### PR TITLE
Fix splash screen

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - jupyter
     - ipython >=4.0.0
     - matplotlib >=1.4.0
+    - pyqt < 5
     - six
 
   run:
@@ -34,6 +35,7 @@ requirements:
     - jupyter
     - ipython >=4.0.0
     - matplotlib >=1.4.0
+    - pyqt < 5
 
 test:
   imports:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -349,20 +349,17 @@ class NXPlotView(QtGui.QDialog):
             self.add_menu_action()
             self.show()
 
-        #Add dummy NXdata group to ensure properties resolve properly
-        self.data = self.plotdata = NXdata((0,1), [(0,1)], 
-                                           title='Title')
-
-        #Display the NeXpy logo in the plotting window
-        self.figure.clf()
-        self.ax.imshow(logo)
-        self.ax.axes.get_xaxis().set_visible(False)
-        self.ax.axes.get_yaxis().set_visible(False)
-        self.draw()
-
+        self.display_logo()
 
     def __repr__(self):
         return 'NXPlotView("%s")' % self.label
+
+    def display_logo(self):
+        self.plot(NXdata(logo, title='NeXpy'), image=True)
+        self.ax.axes.get_xaxis().set_visible(False)
+        self.ax.axes.get_yaxis().set_visible(False)
+        self.ax.title.set_visible(False)
+        self.draw()
 
     def make_active(self):
         """Make this window active for plotting."""

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3761,7 +3761,8 @@ class CustomizeDialog(BaseDialog):
             self.plotview.grid(self.plotview._grid)
             self.plotview.skew = _skew_angle
             self.plotview.aspect = self.plotview._aspect
-            if self.plotview.projection_panel._rectangle is not None:
+            if (self.plotview.projection_panel is not None and
+                    self.plotview.projection_panel._rectangle is not None):
                 self.plotview.projection_panel._rectangle.set_edgecolor(
                     self.plotview._gridcolor)
         else:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -356,8 +356,8 @@ class NXPlotView(QtGui.QDialog):
 
     def display_logo(self):
         self.plot(NXdata(logo, title='NeXpy'), image=True)
-        self.ax.axes.get_xaxis().set_visible(False)
-        self.ax.axes.get_yaxis().set_visible(False)
+        self.ax.xaxis.set_visible(False)
+        self.ax.yaxis.set_visible(False)
         self.ax.title.set_visible(False)
         self.draw()
 


### PR DESCRIPTION
* Fixes problems if the user attempts to use the plotting tabs on the initial NeXpy logo display. Now the logo is displayed using the standard plot function with invisible annotations.
* Adds PyQt4 as a dependency in the conda recipe. This ensures that conda does not attempt to update to PyQt5, while allowing pip installations to still use pyside.