### PR TITLE
Replace argument in QApplication call to empty list

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -235,7 +235,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         """Initialize the GUI."""
         self.app = QtWidgets.QApplication.instance()
         if self.app is None:
-            self.app = QtWidgets.QApplication(['nexpy'])
+            self.app = QtWidgets.QApplication([])
         self.app.setApplicationName('nexpy')
         self.window = MainWindow(self, self.tree, self.settings, self.config)
         self.window.log = self.log


### PR DESCRIPTION
For some reason, PySide cannot handle Unicode arguments when calling QApplication (https://bugreports.qt.io/browse/PYSIDE-306). In any case, this should contain command-line arguments designed to modify the Qt behavior, so the original string is redundant.