### PR TITLE
Fix problem with plugin imports and PyQt5 exceptions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   build:
     - python
     - setuptools
-    - nexusformat >=0.4.7
+    - nexusformat >=0.4.9
     - numpy >=1.6.0
     - scipy
     - h5py
@@ -28,7 +28,7 @@ requirements:
 
   run:
     - python
-    - nexusformat >=0.4.7
+    - nexusformat >=0.4.9
     - numpy >=1.6.0
     - scipy
     - h5py

--- a/doc/source/pythongui.rst
+++ b/doc/source/pythongui.rst
@@ -148,7 +148,7 @@ File Menu
      Provides the ability to restore or delete an existing backup stored in
      ``~/.nexpy/backups``. Restoring the backup is equivalent to opening the
      existing backup file. It is necessary to save it to a new location to 
-     prevent its automatic deletion after three days.
+     prevent its automatic deletion after five days.
 
 **Open Scratch File...**
      Saved projections and fits are stored in a scratch file called ``w0.nxs``,

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -32,7 +32,7 @@ from .pyqt import QtCore, QtGui, QtWidgets
 
 from .mainwindow import MainWindow
 from .treeview import NXtree
-from .utils import NXConfigParser, timestamp_age
+from .utils import NXConfigParser, timestamp_age, report_exception
 
 from nexusformat.nexus import NXroot, nxclasses, nxload
 
@@ -136,7 +136,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         help="Start the console window with the menu bar hidden.")
 
     plain = CBool(False, config=True,
-        help="Use a plaintext widget instead of rich text (plain can't print/save).")
+        help="Use a plaintext widget instead of rich text.")
 
     display_banner = CBool(True, config=True,
         help="Whether to display a banner upon starting the QtConsole."
@@ -206,7 +206,8 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         value = os.getenv("NEXPY_LOG")
         if value == None:
             log_file = os.path.join(self.nexpy_dir, 'nexpy.log')
-            hdlr = logging.handlers.RotatingFileHandler(log_file, maxBytes=50000,
+            hdlr = logging.handlers.RotatingFileHandler(log_file, 
+                                                        maxBytes=50000,
                                                         backupCount=5)
             fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
             fmtr = logging.Formatter(fmt, None)
@@ -237,6 +238,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         if self.app is None:
             self.app = QtWidgets.QApplication([])
         self.app.setApplicationName('nexpy')
+        sys.excepthook = report_exception
         self.window = MainWindow(self, self.tree, self.settings, self.config)
         self.window.log = self.log
         global _mainwindow
@@ -292,7 +294,8 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
                 name = self.window.treeview.tree.get_name(fname)
                 self.window.treeview.tree[name] = self.window.user_ns[name] \
                                                 = nxload(fname)
-                self.window.treeview.select_node(self.window.treeview.tree[name])
+                self.window.treeview.select_node(
+                    self.window.treeview.tree[name])
                 logging.info("NeXus file '%s' opened as workspace '%s'"
                               % (fname, name))
                 self.window.user_ns[name].plot()

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -195,11 +195,9 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         for backup in backups:
             if not (os.path.exists(backup) and 
                     os.path.realpath(backup).startswith(self.backup_dir)):
-                self.settings.remove_option('backups', backup)
-            elif backup_age(backup) > 3:
-                os.remove(os.path.realpath(backup))
-                os.rmdir(os.path.dirname(os.path.realpath(backup))) 
-                self.settings.remove_option('backups', backup)
+            elif backup_age(backup) > 5:
+                shutil.rmtree(os.path.dirname(os.path.realpath(backup))
+            self.settings.remove_option('backups', backup)
         self.settings.save()
 
     def init_log(self):

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -195,9 +195,10 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         for backup in backups:
             if not (os.path.exists(backup) and 
                     os.path.realpath(backup).startswith(self.backup_dir)):
+                self.settings.remove_option('backups', backup)
             elif backup_age(backup) > 5:
-                shutil.rmtree(os.path.dirname(os.path.realpath(backup))
-            self.settings.remove_option('backups', backup)
+                shutil.rmtree(os.path.dirname(os.path.realpath(backup)))
+                self.settings.remove_option('backups', backup)
         self.settings.save()
 
     def init_log(self):

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -11,7 +11,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import imp
+import importlib
 import logging
 import os
 import re
@@ -176,7 +176,8 @@ class FitDialog(BaseDialog):
                 name, ext = os.path.splitext(file_)
                 if name != '__init__' and ext.startswith('.py'):
                     filenames.add(name)
-        functions_path = pkg_resources.resource_filename('nexpy.api.frills', 'functions')
+        functions_path = pkg_resources.resource_filename('nexpy.api.frills', 
+                                                         'functions')
         sys.path.append(functions_path)
         for file_ in os.listdir(functions_path):
             name, ext = os.path.splitext(file_)
@@ -184,14 +185,14 @@ class FitDialog(BaseDialog):
                 filenames.add(name)
         self.function_module = {}
         for name in sorted(filenames):
-            fp, pathname, description = imp.find_module(name)
             try:
-                function_module = imp.load_module(name, fp, pathname, description)
-            finally:
-                if fp:
-                    fp.close()
-            if hasattr(function_module, 'function_name'):
-                self.function_module[function_module.function_name] = function_module
+                function_module = importlib.import_module(name)
+                if hasattr(function_module, 'function_name'):
+                    self.function_module[function_module.function_name] = \
+                        function_module
+            except ImportError:
+                pass
+                
 
     def initialize_parameter_grid(self):
         grid_layout = QtWidgets.QVBoxLayout()

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -63,12 +63,7 @@ class NXRichJupyterWidget(RichJupyterWidget):
 
 class MainWindow(QtWidgets.QMainWindow):
 
-    #---------------------------------------------------------------------------
-    # 'object' interface
-    #---------------------------------------------------------------------------
-
     _magic_menu_dict = {}
-
 
     def __init__(self, app, tree, settings, config):
         """ Create a MainWindow for the application
@@ -111,7 +106,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.console = NXRichJupyterWidget(config=self.config, parent=rightpane)
         self.console.setMinimumSize(700, 100)
-        self.console.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        self.console.setSizePolicy(QtWidgets.QSizePolicy.Expanding, 
+                                   QtWidgets.QSizePolicy.Fixed)
         self.console._confirm_exit = True
         self.console.kernel_manager = QtInProcessKernelManager(config=self.config)
         self.console.kernel_manager.start_kernel()
@@ -149,7 +145,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.treeview = NXTreeView(self.tree, parent=self)
         self.treeview.setMinimumWidth(200)
         self.treeview.setMaximumWidth(400)
-        self.treeview.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)
+        self.treeview.setSizePolicy(QtWidgets.QSizePolicy.Preferred, 
+                                    QtWidgets.QSizePolicy.Expanding)
         self.user_ns['plotview'] = self.plotview
         self.user_ns['plotviews'] = self.plotviews = self.plotview.plotviews
         self.user_ns['treeview'] = self.treeview
@@ -1426,11 +1423,13 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             node = self.treeview.get_node()
             if isinstance(node, NXlink):
-                if node.nxfilename and node.nxfilename != node.nxroot.nxfilename:
+                if (node.nxfilename and 
+                    node.nxfilename != node.nxroot.nxfilename):
                     fname = node.nxfilename
                     if not os.path.isabs(fname):
-                        fname = os.path.join(os.path.dirname(node.nxroot.nxfilename),
-                                             node.nxfilename)
+                        fname = os.path.join(
+                            os.path.dirname(node.nxroot.nxfilename),
+                            node.nxfilename)
                     name = self.tree.node_from_file(fname)
                     if name is None:
                         name = self.tree.get_name(fname)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -930,7 +930,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.treeview.select_node(self.tree[name].entry)
                 self.treeview.update()
                 logging.info("New workspace '%s' created" % name)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Creating New Workspace", error)
 
     def open_file(self):
@@ -945,7 +945,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 logging.info("NeXus file '%s' opened as workspace '%s'"
                              % (fname, name))
                 self.update_recent_files(fname)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening File", error)
 
     def open_editable_file(self):
@@ -960,7 +960,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 logging.info("NeXus file '%s' opened (unlocked) as workspace '%s'"
                              % (fname, name))
                 self.update_recent_files(fname)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening File (Read/Write)", error)
 
     def open_recent_file(self):
@@ -973,7 +973,7 @@ class MainWindow(QtWidgets.QMainWindow):
             logging.info("NeXus file '%s' opened as workspace '%s'"
                          % (fname, name))
             self.update_recent_files(fname)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening Recent File", error)
 
     def open_remote_file(self):
@@ -981,7 +981,7 @@ class MainWindow(QtWidgets.QMainWindow):
             dialog = RemoteDialog(parent=self)
             dialog.setModal(False)
             dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening Remote File", error)
 
     def hover_recent_menu(self, action):
@@ -1041,7 +1041,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.default_directory = os.path.dirname(fname)
                 logging.info("NeXus workspace '%s' saved as '%s'"
                              % (old_name, fname))
-        except Exception as error:
+        except NeXusError as error:
             report_error("Saving File", error)
 
     def duplicate(self):
@@ -1075,7 +1075,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.treeview.update()
             else:
                 raise NeXusError("Only NXroot groups can be duplicated")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Duplicating File", error)
 
     def reload(self):
@@ -1092,7 +1092,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.treeview.select_node(self.tree[name][path])
                 except Exception:
                     pass
-        except Exception as error:
+        except NeXusError as error:
             report_error("Reloading File", error)
 
     def remove(self):
@@ -1105,7 +1105,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 if ret == QtWidgets.QMessageBox.Ok:
                     del self.tree[name]
                     logging.info("Workspace '%s' removed" % name)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Removing File", error)
 
     def show_import_dialog(self):
@@ -1113,7 +1113,7 @@ class MainWindow(QtWidgets.QMainWindow):
             import_module = self.importer[self.sender()]
             self.import_dialog = import_module.ImportDialog(parent=self)
             self.import_dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Importing File", error)
 
     def import_data(self):
@@ -1138,7 +1138,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 except Exception:
                     pass
                 logging.info("Workspace '%s' imported" % name)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Importing File", error)
 
     def lock_file(self):
@@ -1150,7 +1150,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 logging.info("Workspace '%s' locked" % node.nxname)
             else:
                 raise NeXusError("Can only lock a NXroot group")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Locking File", error)
 
     def unlock_file(self):
@@ -1162,7 +1162,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.treeview.update()
             else:
                 raise NeXusError("Can only unlock a NXroot group")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Unlocking File", error)
 
     def backup_file(self):
@@ -1179,7 +1179,7 @@ class MainWindow(QtWidgets.QMainWindow):
                              % (node.nxname, node.nxbackup))
             else:
                 raise NeXusError("Can only backup a NXroot group")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Backing Up File", error)
 
     def restore_file(self):
@@ -1196,20 +1196,20 @@ class MainWindow(QtWidgets.QMainWindow):
                     logging.info("Workspace '%s' backed up" % node.nxname)
             else:
                 raise NeXusError("Can only restore a NXroot group")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Restoring File", error)
 
     def manage_backups(self):
         try:
             dialog = ManageBackupsDialog(parent=self)
             dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Managing Backups", error)
 
     def open_scratch_file(self):
         try:
             self.tree['w0'] = nxload(self.scratch_file, 'rw')
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening Scratch File", error)
 
     def purge_scratch_file(self):
@@ -1221,7 +1221,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     for entry in self.tree['w0'].entries.copy():
                         del self.tree['w0'][entry]
                     logging.info("Workspace 'w0' purged")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Purging Scratch File", error)
 
     def close_scratch_file(self):
@@ -1235,21 +1235,21 @@ class MainWindow(QtWidgets.QMainWindow):
                         del self.tree['w0'][entry]
                     logging.info("Workspace 'w0' purged")
                 del self.tree['w0']
-        except Exception as error:
+        except NeXusError as error:
             report_error("Purging Scratch File", error)
 
     def install_plugin(self):
         try:
             dialog = InstallPluginDialog(parent=self)
             dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Installing Plugin", error)
 
     def remove_plugin(self):
         try:
             dialog = RemovePluginDialog(parent=self)
             dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Removing Plugin", error)
 
     def plot_data(self):
@@ -1268,7 +1268,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     dialog.show()
                 else:
                     raise NeXusError("Data not plottable")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Plotting Data", error)
 
     def overplot_data(self):
@@ -1277,7 +1277,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if node is not None:
                 self.treeview.status_message(node)
                 node.oplot(fmt='o')
-        except Exception as error:
+        except NeXusError as error:
             report_error("Overplotting Data", error)
 
     def plot_line(self):
@@ -1296,7 +1296,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     dialog.show()
                 else:
                     raise NeXusError("Data not plottable")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Plotting Data", error)
 
     def overplot_line(self):
@@ -1305,7 +1305,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if node is not None:
                 self.treeview.status_message(node)
                 node.oplot(fmt='-')
-        except Exception as error:
+        except NeXusError as error:
             report_error("Overplotting Data", error)
 
     def plot_image(self):
@@ -1314,7 +1314,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if node is not None:
                 self.treeview.status_message(node)
                 node.implot()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Plotting RGB(A) Image Data", error)
 
     def view_data(self):
@@ -1322,7 +1322,7 @@ class MainWindow(QtWidgets.QMainWindow):
             node = self.treeview.get_node()
             self.viewdialog = ViewDialog(node, parent=self)
             self.viewdialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Viewing Data", error)
 
     def add_data(self):
@@ -1335,7 +1335,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 dialog.exec_()
             else:
                 self.new_workspace()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Adding Data", error)
 
     def initialize_data(self):
@@ -1349,7 +1349,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     dialog.exec_()
                 else:
                     raise NeXusError("An NXfield can only be added to an NXgroup")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Initializing Data", error)
 
     def rename_data(self):
@@ -1366,7 +1366,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                      % (path, node.nxpath))
                     else:
                         raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Renaming Data", error)
 
     def copy_data(self):
@@ -1377,7 +1377,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 logging.info("'%s' copied" % self.copied_node.nxpath)
             else:
                 raise NeXusError("Use 'Duplicate File' to copy an NXroot group")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Copying Data", error)
 
     def paste_data(self):
@@ -1390,7 +1390,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                  % (self.copied_node.nxpath, node.nxpath))
                 else:
                     raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Pasting Data", error)
 
     def paste_link(self):
@@ -1403,7 +1403,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                  % (self.copied_node.nxpath, node.nxpath))
                 else:
                     raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Pasting Data as Link", error)
 
     def delete_data(self):
@@ -1419,7 +1419,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                      (node.nxroot.nxname+node.nxpath))
                 else:
                     raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Deleting Data", error)
 
     def show_link(self):
@@ -1440,7 +1440,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 else:
                     self.treeview.select_node(node.nxlink)
                 self.treeview.update()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Showing Link", error)
 
     def set_signal(self):
@@ -1453,7 +1453,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     logging.info("Signal set for '%s'" % node.nxgroup.nxpath)
                 else:
                     raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Setting Signal", error)
 
     def set_default(self):
@@ -1474,7 +1474,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     logging.info("Default set to '%s'" % node.nxpath)
                 else:
                     raise NeXusError("NeXus file is locked")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Setting Default", error)
 
     def fit_data(self):
@@ -1502,7 +1502,7 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 raise NeXusError(
                     "Fitting only enabled for one-dimensional data")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Fitting Data", error)
 
     def input_base_classes(self):
@@ -1732,21 +1732,21 @@ class MainWindow(QtWidgets.QMainWindow):
             from .plotview import plotview
             dialog = LimitDialog(parent=self)
             dialog.exec_()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Changing Plot Limits", error)
 
     def reset_axes(self):
         try:
             from .plotview import plotview
             plotview.reset_plot_limits()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Resetting Plot Limits", error)
 
     def show_log(self):
         try:
             dialog = LogDialog(parent=self)
             dialog.show()
-        except Exception as error:
+        except NeXusError as error:
             report_error("Showing Log File", error)
 
     def show_projection_panel(self):
@@ -1770,7 +1770,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.editors.setVisible(True)
             self.editors.raise_()
             logging.info("Creating new script")
-        except Exception as error:
+        except NeXusError as error:
             report_error("Editing New Script", error)
 
     def open_script(self):
@@ -1785,7 +1785,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.editors.setVisible(True)
                 self.editors.raise_()
                 logging.info("NeXus script '%s' opened" % file_name)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Editing Script", error)
 
     def open_script_file(self):
@@ -1796,7 +1796,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.editors.setVisible(True)
             self.editors.raise_()
             logging.info("NeXus script '%s' opened" % file_name)
-        except Exception as error:
+        except NeXusError as error:
             report_error("Opening Script", error)
 
     def add_script_action(self, file_name):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -359,17 +359,23 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.file_menu.addSeparator()
 
-        self.install_plugin_action=QtWidgets.QAction("Install Plugin",
+        self.install_plugin_action=QtWidgets.QAction("Install Plugin...",
             self,
             triggered=self.install_plugin
             )
         self.add_menu_action(self.file_menu, self.install_plugin_action)
 
-        self.remove_plugin_action=QtWidgets.QAction("Remove Plugin",
+        self.remove_plugin_action=QtWidgets.QAction("Remove Plugin...",
             self,
             triggered=self.remove_plugin
             )
         self.add_menu_action(self.file_menu, self.remove_plugin_action)
+
+        self.restore_plugin_action=QtWidgets.QAction("Restore Plugin...",
+            self,
+            triggered=self.restore_plugin
+            )
+        self.add_menu_action(self.file_menu, self.restore_plugin_action)
 
         self.file_menu.addSeparator()
 
@@ -1248,6 +1254,13 @@ class MainWindow(QtWidgets.QMainWindow):
             dialog.show()
         except NeXusError as error:
             report_error("Removing Plugin", error)
+
+    def restore_plugin(self):
+        try:
+            dialog = RestorePluginDialog(parent=self)
+            dialog.show()
+        except NeXusError as error:
+            report_error("Restoring Plugin", error)
 
     def plot_data(self):
         try:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3290,8 +3290,9 @@ class NXProjectionPanel(QtWidgets.QWidget):
     def save_projection(self):
         try:
             axes, limits = self.get_projection()
-            keep_data(self.plotview.data.project(axes, limits, summed=self.summed))
-        except NeXusError as error:
+            keep_data(self.plotview.data.project(axes, limits,
+                                                 summed=self.summed))
+        except Exception as error:
             report_error("Saving Projection", error)
 
     def plot_projection(self):
@@ -3317,7 +3318,7 @@ class NXProjectionPanel(QtWidgets.QWidget):
             self.plotview.make_active()
             plotviews[projection.label].raise_()
             self.panels.update()
-        except NeXusError as error:
+        except Exception as error:
             report_error("Plotting Projection", error)
 
     def mask_data(self):
@@ -3325,7 +3326,7 @@ class NXProjectionPanel(QtWidgets.QWidget):
             limits = tuple(slice(x,y) for x,y in self.get_limits())
             self.plotview.data.nxsignal[limits] = np.ma.masked
             self.plotview.replot_data()
-        except NeXusError as error:
+        except Exception as error:
             report_error("Masking Data", error)
 
     def unmask_data(self):
@@ -3333,7 +3334,7 @@ class NXProjectionPanel(QtWidgets.QWidget):
             limits = tuple(slice(x,y) for x,y in self.get_limits())
             self.plotview.data.nxsignal.mask[limits] = np.ma.nomask
             self.plotview.replot_data()
-        except NeXusError as error:
+        except Exception as error:
             report_error("Masking Data", error)
 
     def spinbox(self):

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -60,7 +60,8 @@ def report_exception(error_type, error, traceback):
     """Display and log an uncaught exception with its traceback"""
     message = ''.join(tb.format_exception_only(error_type, error))
     information = ''.join(tb.format_exception(error_type, error, traceback))
-    logging.error(type(error).__name__, exc_info=(error_type, error, traceback))
+    logging.error('Exception in GUI event loop', 
+                  exc_info=(error_type, error, traceback))
     message_box = QtWidgets.QMessageBox()
     message_box.setText(message)
     message_box.setInformativeText(information)

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -81,6 +81,7 @@ def find_nearest(array, value):
 def find_nearest_index(array, value):
     return (np.abs(array-value)).argmin()
 
+
 def human_size(bytes):
     """Convert a file size to human-readable form"""
     size = np.float(bytes)
@@ -102,7 +103,14 @@ def read_timestamp(time_string):
 
 def format_timestamp(time_string):
     """Return the timestamp as a formatted string."""
-    return datetime.strptime(time_string, '%Y%m%d%H%M%S').isoformat().replace('T', ' ')
+    return datetime.strptime(time_string, 
+                             '%Y%m%d%H%M%S').isoformat().replace('T', ' ')
+
+
+def restore_timestamp(time_string):
+    """Return a timestamp from a formatted string."""
+    return datetime.strptime(time_string, 
+                             "%Y-%m-%d %H:%M:%S").strftime('%Y%m%d%H%M%S')
 
 
 def timestamp_age(time_string):
@@ -158,6 +166,8 @@ class NXConfigParser(ConfigParser, object):
             self.add_section('recent')
         if 'backups' not in sections:
             self.add_section('backups')
+        if 'plugins' not in sections:
+            self.add_section('plugins')
         if 'recentFiles' in self.options('recent'):
             self.fix_recent()
 
@@ -174,7 +184,8 @@ class NXConfigParser(ConfigParser, object):
 
     def fix_recent(self):
         """Perform backward compatibility fix"""
-        paths = [f.strip() for f in self.get('recent', 'recentFiles').split(',')]
+        paths = [f.strip() for f 
+                 in self.get('recent', 'recentFiles').split(',')]
         for path in paths:
             self.set("recent", path)
         self.remove_option("recent", "recentFiles")

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -1,11 +1,13 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import importlib
+import logging
 import os
 import re
 import sys
 from collections import OrderedDict
 from datetime import datetime
+import traceback as tb
 try:
     from configparser import ConfigParser
 except ImportError:
@@ -51,6 +53,20 @@ def display_message(message, information=None):
     message_box.setText(message)
     if information:
         message_box.setInformativeText(information)
+    return message_box.exec_()
+
+
+def report_exception(error_type, error, traceback):
+    """Display and log an uncaught exception with its traceback"""
+    message = ''.join(tb.format_exception_only(error_type, error))
+    information = ''.join(tb.format_exception(error_type, error, traceback))
+    logging.error(type(error).__name__, exc_info=(error_type, error, traceback))
+    message_box = QtWidgets.QMessageBox()
+    message_box.setText(message)
+    message_box.setInformativeText(information)
+    message_box.setIcon(QtWidgets.QMessageBox.Warning)
+    layout = message_box.layout()
+    layout.setColumnMinimumWidth(layout.columnCount()-1, 500)
     return message_box.exec_()
 
 


### PR DESCRIPTION
This pull request fixes two bugs caused by changes in the behavior of other packages, and adds an enhancement.

1. Previously, plugins were imported with the `imp` module, but this is now deprecated in favor of the `importlib` module, which treats module searches differently.
2. PyQt5 now requires exceptions to be explicitly customized by changing `sys.excepthook`. Otherwise, it aborts the program even if the exception is trapped. This pull request now provides a dialog box for all uncaught exceptions, which includes a full traceback.
3. There is a new 'Restore Plugins...' menu item to allow backups to be restored. If it replaces an existing plugin, then the original is backed up instead.