### PR TITLE
Minor enhancements and bug fixes

### DIFF
--- a/doc/source/pythongui.rst
+++ b/doc/source/pythongui.rst
@@ -77,7 +77,7 @@ File Menu
     allow modifications to the file (see below).
 
     .. note:: It is possible to open a file in directly read/write mode using 
-              the keyboard shortcut Alt-Shift-O (Cmd-Shift-O on a Mac). Note 
+              the keyboard shortcut Ctrl+Shift+O (⌘+⇧+O on a Mac). Note 
               that any changes to the file tree, using either the shell or GUI 
               commands, will be automatically updated in the file.
 
@@ -317,6 +317,18 @@ Data Menu
 
 Window Menu
 ^^^^^^^^^^^
+**Show Tree**
+    Brings the tree view to the front and give it keyboard focus.
+
+    .. note:: This has the keyboard shortcut of Ctrl+Shift+T (⌘+⇧+T on a 
+              Mac).
+
+**Show IPython Shell**
+    Brings the shell to the front and give it keyboard focus.
+
+    .. note:: This has the keyboard shortcut of Ctrl+Shift+I (⌘+⇧+I on a 
+              Mac).
+
 **Show Log File**
     Opens a text window displaying the NeXpy log file(s). These files, which are
     stored in ``~/.nexpy/nexpy.log``, ``~/.nexpy/nexpy.log.1``, *etc*., 
@@ -328,12 +340,12 @@ Window Menu
               be rendered in the terminal using ``less -r``.
 
 **Show Projection Panel**
-    Show the projection panel for the currently active plotting window. This is
+    Shows the projection panel for the currently active plotting window. This is
     equivalent to clicking on 'Show Panel' in the projection tab (see below). 
     All the open projection panels are displayed as tabs in a single window.
 
 **Show Script Editor**
-    Show the script editor. If multiple scripts are open, they are displayed as
+    Shows the script editor. If multiple scripts are open, they are displayed as
     tabs in a single window. If no scripts are open, this will open a new 
     script.
 
@@ -456,7 +468,8 @@ and sliders.
     If a diverging color scale is used, the signal is assumed to be symmetric 
     about 0, so the minimum box and slider are disabled and their values set to 
     the negative of the maximum values. If a log scale is chosen, a `symmetric 
-    log plot <http://matplotlib.org/users/colormapnorms.html#symmetric-logarithmic>`_ 
+    log plot 
+    <http://matplotlib.org/users/colormapnorms.html#symmetric-logarithmic>`_ 
     is displayed, with threshold and scale parameters adjustable using the 
     command-line `symlog` command (see below).
     
@@ -736,6 +749,30 @@ and sliders.
             that are ideal for displaying symmetric log data. Some are available
             at the bottom of the color map dropdown menu in the Signal tab.
 
+**Keyboard Shortcuts**
+
+    With v0.10.6, a number of keyboard shortcuts are defined when focus is on
+    the plotting window. These can be used to switch between tabs or set
+    various plotting options.
+
+    .. note:: Keyboard focus can be switched to a particular plotting window by 
+              (a) clicking within the window, (b) using the Window menu, or (c) 
+              typing Ctrl+'n' (⌘+'n' on a Mac), where 'n' is the plot window 
+              number.
+
+    * **s** - switch to the Signal tab. 
+    * **x** - switch to the X tab.
+    * **y** - switch to the Y tab.
+    * **z** - switch to the Z tab.
+    * **p** - switch to the Projection tab.
+    * **o** - switch to the Options tab.
+    * **l** - toggle logarithmic signal scale (2D plots only).
+    * **P** - toggle panning mode (if enabled, zoom mode is disabled).
+    * **Z** - toggle zoom mode (if enabled, pan mode is disabled).
+    * **E** - toggle the aspect ratio between 'equal' and 'automatic'.
+    * **S** - save plot to a graphics file.
+    * **A** - add plotted data to the tree pane.
+    * **O** - open dialog to customize plots. 
 
 Fitting NeXus Data
 ------------------
@@ -756,6 +793,10 @@ plotting window and the fitting parameters displayed in a message window.
           entered in the Fit Dialog. These values can be changed between
           fits if required, or reset to the overall range of the data using the
           ``Reset Limits`` button.
+
+.. note:: With v0.10.6, the keyboard shortcuts 'l' and 'r' can 
+          be used to set the X-axis limits in the fit dialog to the current 
+          cursor position in the canvas.
 
 The original data, the fitted data, constituent functions, and the parameters
 can all be saved to an NXentry group in the Tree Pane for subsequent plotting, 
@@ -801,11 +842,15 @@ before estimating the peak parameters. Obviously, the more functions that are
 added, the less reliable the guesses will be. Starting parameters will have to 
 be entered manually before the fit in those cases.
 
-.. note:: The X-range used in 'guessing' the parameters can be adjusted by 
-          setting the X-axis limits in the Fit Dialog. 
-
 .. note:: If it is not possible to estimate starting parameters, just return
           values that do not trigger an exception. 
+
+.. note:: The X-range used in 'guessing' the parameters can be adjusted by 
+          setting the X-axis limits in the Fit Dialog.
+
+.. note:: With v0.10.6, the keyboard shortcuts 'l' and 'r' can 
+          be used to set the X-axis limits in the fit dialog to the current 
+          cursor position in the canvas.
 
 Importing NeXus Data
 --------------------

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -841,9 +841,14 @@ class CustomizeDialog(BaseDialog):
             self.set_layout(pl.grid(header=False),
                             self.curve_grids,
                             self.close_buttons())
+            self.setTabOrder(self.parameters['labels']['ylabel'].box, 
+                             self.curve_box)
         self.update_colors()
         self.set_title('Customize %s' % self.plotview.label)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setTabOrder(self.apply_button, self.cancel_button)
+        self.setTabOrder(self.cancel_button, self.save_button)
+        self.parameters['labels']['title'].box.setFocus()
 
     def close_buttons(self):
         buttonbox = QtWidgets.QDialogButtonBox(self)
@@ -851,12 +856,17 @@ class CustomizeDialog(BaseDialog):
         buttonbox.setStandardButtons(QtWidgets.QDialogButtonBox.Apply|
                                      QtWidgets.QDialogButtonBox.Cancel|
                                      QtWidgets.QDialogButtonBox.Save)
-        buttonbox.setFocusPolicy(QtCore.Qt.StrongFocus)
+        buttonbox.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.apply_button = buttonbox.button(QtWidgets.QDialogButtonBox.Apply)
+        self.apply_button.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.apply_button.setDefault(True)
+        self.cancel_button = buttonbox.button(QtWidgets.QDialogButtonBox.Cancel)
+        self.cancel_button.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.save_button = buttonbox.button(QtWidgets.QDialogButtonBox.Save)
+        self.save_button.setFocusPolicy(QtCore.Qt.StrongFocus)
         buttonbox.accepted.connect(self.accept)
         buttonbox.rejected.connect(self.reject)
-        buttonbox.button(
-            QtWidgets.QDialogButtonBox.Apply).clicked.connect(self.apply)
-        buttonbox.button(QtWidgets.QDialogButtonBox.Apply).setDefault(True)
+        self.apply_button.clicked.connect(self.apply)
         return buttonbox
 
     def update(self):
@@ -1966,6 +1976,7 @@ class LogDialog(BaseDialog):
         self.text_box = QtWidgets.QTextEdit()
         self.text_box.setMinimumWidth(800)
         self.text_box.setMinimumHeight(600)
+        self.text_box.setFocusPolicy(QtCore.Qt.NoFocus)
         layout.addWidget(self.text_box)
         footer_layout = QtWidgets.QHBoxLayout()
         self.file_combo = NXComboBox(self.show_log)
@@ -1974,6 +1985,8 @@ class LogDialog(BaseDialog):
             self.file_combo.addItem(file_name)
         self.file_combo.setCurrentIndex(self.file_combo.findText('nexpy.log'))
         close_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Close)
+        close_box.setFocusPolicy(QtCore.Qt.StrongFocus)
+        close_box.setFocus()
         close_box.rejected.connect(self.reject)
         footer_layout.addStretch()
         footer_layout.addWidget(self.file_combo)

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1731,18 +1731,21 @@ class InitializeDialog(BaseDialog):
             raise NeXusError("Invalid fill value")
 
     def accept(self):
-        name = self.get_name()
-        if name:
-            dtype = self.dtype
-            shape = self.shape
-            fillvalue = self.fillvalue
-            self.node[name] = NXfield(dtype=dtype, shape=shape, 
-                                      fillvalue=fillvalue)
-            logging.info("'%s' initialized in '%s'" 
+        try:
+            name = self.get_name().strip()
+            if name:
+                dtype = self.dtype
+                shape = self.shape
+                fillvalue = self.fillvalue
+                self.node[name] = NXfield(dtype=dtype, shape=shape, 
+                                          fillvalue=fillvalue)
+                logging.info("'%s' initialized in '%s'" 
                          % (self.node[name], self.node.nxpath)) 
-            super(InitializeDialog, self).accept()
-        else:
-            raise NeXusError("Invalid name")
+                super(InitializeDialog, self).accept()
+            else:
+                raise NeXusError("Invalid name")
+        except NeXusError as error:
+            report_error("Initializing Data", error)
 
     
 class RenameDialog(BaseDialog):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1182,24 +1182,24 @@ class MainWindow(QtWidgets.QMainWindow):
     def lock_file(self):
         try:
             node = self.treeview.get_node()
-            if isinstance(node, NXroot):
+            if isinstance(node, NXroot) and node.nxfilemode:
                 node.lock()
                 self.treeview.update()
                 logging.info("Workspace '%s' locked" % node.nxname)
             else:
-                raise NeXusError("Can only lock a NXroot group")
+                raise NeXusError("Can only lock a saved NXroot group")
         except NeXusError as error:
             report_error("Locking File", error)
 
     def unlock_file(self):
         try:
             node = self.treeview.get_node()
-            if isinstance(node, NXroot):
+            if isinstance(node, NXroot) and node.nxfilemode:
                 dialog = UnlockDialog(node, parent=self)
                 dialog.show()
                 self.treeview.update()
             else:
-                raise NeXusError("Can only unlock a NXroot group")
+                raise NeXusError("Can only unlock a saved NXroot group")
         except NeXusError as error:
             report_error("Unlocking File", error)
 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -121,7 +121,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.console.show()
 
         self.shellview = self.console._control
-        self.shellview.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.shellview.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         if 'gui_completion' not in self.config['ConsoleWidget']:
             self.console.gui_completion = 'droplist'
@@ -182,6 +182,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.setWindowTitle('NeXpy v'+__version__)
         self.statusBar().showMessage('Ready')
+
         self.shellview.setFocus()
 
     @property

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1710,8 +1710,9 @@ class MainWindow(QtWidgets.QMainWindow):
         menulabel : str
             Label for the menu
 
-        Will infere the menu name from the identifier at creation if menulabel not given.
-        To do so you have too give menuidentifier as a CamelCassedString
+        Will infere the menu name from the identifier at creation if menulabel 
+        not given. To do so you have too give menuidentifier as a 
+        CamelCassedString
         """
         menu = self._magic_menu_dict.get(menuidentifier,None)
         if not menu :
@@ -1728,14 +1729,14 @@ class MainWindow(QtWidgets.QMainWindow):
             self.active_action[number] = QtWidgets.QAction(label,
                 self,
                 shortcut=QtGui.QKeySequence("Ctrl+Shift+Alt+P"),
-                triggered=lambda: self.plotviews[label].raise_(),
+                triggered=lambda: self.plotviews[label].make_active(),
                 checkable=False)
             self.window_menu.addAction(self.active_action[number])
         elif label == 'Fit':
             self.active_action[number] = QtWidgets.QAction(label,
                 self,
                 shortcut=QtGui.QKeySequence("Ctrl+Shift+Alt+F"),
-                triggered=lambda: self.plotviews[label].raise_(),
+                triggered=lambda: self.plotviews[label].make_active(),
                 checkable=False)
             self.window_menu.addAction(self.active_action[number])
         else:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -473,14 +473,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def init_data_menu(self):
         self.data_menu = self.menu_bar.addMenu("Data")
 
-        plotkey = QtGui.QKeySequence(QtGui.QKeySequence.Print)
-        if plotkey.matches("Ctrl+P") and sys.platform != 'darwin':
-            # Only override the default if there is a collision.
-            # Qt ctrl = cmd on OSX, so the match gets a false positive on OSX.
-            plotkey = "Ctrl+Shift+P"
         self.plot_data_action=QtWidgets.QAction("&Plot Data",
             self,
-            shortcut=plotkey,
+            shortcut="Ctrl+P",
             triggered=self.plot_data
             )
         self.add_menu_action(self.data_menu, self.plot_data_action)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -415,6 +415,8 @@ class NXPlotView(QtWidgets.QDialog):
             Switch to the `x`, `y` or `z` tabs, respectively.
         'p', 'o'
             Switch to the `Projection` or `Option` tab, respectively.
+        'l'
+            Toggle log scale (2D only).
         'A'
             Store the plotted data. This is equivalent to selecting the 
             `Add Data` option button on the toolbar.
@@ -450,14 +452,19 @@ class NXPlotView(QtWidgets.QDialog):
                     self.vtab.log = True
         elif event.key == 's' or event.key == 'v':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.vtab))
+            self.vtab.minbox.setFocus()
         elif event.key == 'x':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.xtab))
+            self.xtab.axiscombo.setFocus()
         elif event.key == 'y':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ytab))
+            self.ytab.axiscombo.setFocus()
         elif event.key == 'z':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ztab))
+            self.ztab.axiscombo.setFocus()
         elif event.key == 'p':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ptab))
+            self.ptab.xbox.setFocus()
         elif event.key == 'o':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.otab))
         elif event.key == 'A':
@@ -565,7 +572,7 @@ class NXPlotView(QtWidgets.QDialog):
         logy : bool
             If True, the y-axis is plotted on a log scale. This is 
             equivalent to 'log=True' for one-dimenional data.
-        skew
+        skew : float
             The value of the skew angle between the x and y axes for 2D 
             plots.
         """
@@ -2330,8 +2337,9 @@ class NXPlotTab(QtWidgets.QWidget):
 
     def combobox(self, slot):
         """Return a QComboBox with a signal slot."""
-        combobox = QtWidgets.QComboBox()
+        combobox = NXComboBox()
         combobox.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
+        combobox.setFocusPolicy(QtCore.Qt.StrongFocus)
         combobox.setMinimumWidth(100)
         combobox.activated.connect(slot)
         return combobox
@@ -2369,8 +2377,10 @@ class NXPlotTab(QtWidgets.QWidget):
         return slider
 
     def checkbox(self, label, slot):
-        """Return a QCheckbox with the specified label and slot."""
-        checkbox = QtWidgets.QCheckBox(label)
+        """Return a checkbox with the specified label and slot."""
+        checkbox = NXCheckBox(label)
+        checkbox.setFocusPolicy(QtCore.Qt.StrongFocus)
+        checkbox.setTristate(False)
         checkbox.setChecked(False)
         checkbox.stateChanged.connect(slot)
         return checkbox
@@ -2951,6 +2961,29 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         elif value < self.minimum():
             self.setMinimum(value)
         super(NXDoubleSpinBox, self).setValue(value)
+
+
+class NXComboBox(QtWidgets.QComboBox):
+
+    def keyPressEvent(self, event):
+        if (event.key() == QtCore.Qt.Key_Up or 
+            event.key() == QtCore.Qt.Key_Down):
+            super(NXComboBox, self).keyPressEvent(event)
+        else:
+            self.parent().keyPressEvent(event)
+
+
+class NXCheckBox(QtWidgets.QCheckBox):
+
+    def keyPressEvent(self, event):
+        if (event.key() == QtCore.Qt.Key_Up or 
+            event.key() == QtCore.Qt.Key_Down):
+            if self.isChecked():
+                self.setCheckState(False)
+            else:
+                self.setCheckState(True)
+        else:
+            self.parent().keyPressEvent(event)
 
 
 class NXProjectionTab(QtWidgets.QWidget):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -345,7 +345,7 @@ class NXPlotView(QtWidgets.QDialog):
 
         # Remove some key default Matplotlib key mappings
         for key in [key for key in mpl.rcParams if key.startswith('keymap')]:
-            for shortcut in 'klopsvxyzAEGOPSZ':
+            for shortcut in 'bfklopsvxyzAEGOPSZ':
                 if shortcut in mpl.rcParams[key]:
                     mpl.rcParams[key].remove(shortcut)
 
@@ -417,6 +417,8 @@ class NXPlotView(QtWidgets.QDialog):
             Switch to the `Projection` or `Option` tab, respectively.
         'l'
             Toggle log scale (2D only).
+        'f', 'b'
+            Play the current z-axis values forward or backward, respectively.
         'A'
             Store the plotted data. This is equivalent to selecting the 
             `Add Data` option button on the toolbar.
@@ -450,6 +452,12 @@ class NXPlotView(QtWidgets.QDialog):
                     self.vtab.log = False
                 else:
                     self.vtab.log = True
+        elif event.key == 'f':
+            self.ztab.playforward()
+        elif event.key == 'b':
+            self.ztab.playback()
+        elif event.key == ' ':
+            self.ztab.pause()
         elif event.key == 's' or event.key == 'v':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.vtab))
             self.vtab.minbox.setFocus()

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2330,8 +2330,8 @@ class NXPlotTab(QtWidgets.QWidget):
         self.axis = axis
         if self.zaxis:
             self.minbox.data = self.maxbox.data = self.axis.centers
-            self.minbox.setRange(0, len(self.axis.data)-1)
-            self.maxbox.setRange(0, len(self.axis.data)-1)
+            self.minbox.setRange(0, len(self.minbox.data)-1)
+            self.maxbox.setRange(0, len(self.maxbox.data)-1)
             self.minbox.setValue(axis.lo)
             self.maxbox.setValue(axis.hi)
             self.minbox.diff = self.maxbox.diff = axis.hi - axis.lo

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -138,7 +138,7 @@ def change_plotview(label):
     Parameters
     ----------
     label : str
-        The label of the plotting window to be activatd.
+        The label of the plotting window to be activated.
     """
     global plotview, plotviews
     if label in plotviews:
@@ -391,8 +391,6 @@ class NXPlotView(QtWidgets.QDialog):
         ----------
         event : Matplotlib KeyEvent
         """
-        if self.number < 101:
-            self.make_active()
         if event.inaxes:
             self.xdata, self.ydata = self.inverse_transform(event.xdata, 
                                                             event.ydata)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2733,6 +2733,7 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.interpcombo.setCurrentIndex(0)
             self._cached_interpolation = interpolation
             self.plotview.interpolate()
+            self._cached_interpolation = self.interpolation
 
     interpolation = property(_interpolation, _set_interpolation, 
                              "Property: Image color map")

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -265,7 +265,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.setMinimumSize(724, 550)
         self.setSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding,
                            QtWidgets.QSizePolicy.MinimumExpanding)
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         global plotview, plotviews
         if label in plotviews:
@@ -275,7 +275,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.number = self.figuremanager.num
         self.canvas = self.figuremanager.canvas
         self.canvas.setParent(self)
-        self.canvas.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.canvas.setFocusPolicy(QtCore.Qt.ClickFocus)
         self.canvas.callbacks.exception_handler = report_exception
 
         Gcf.set_active(self.figuremanager)
@@ -312,7 +312,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.tab_widget.addTab(self.otab, 'options')
         self.currentTab = self.otab
         self.tab_widget.setCurrentWidget(self.currentTab)
-        self.tab_widget.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.tab_widget.setFocusPolicy(QtCore.Qt.NoFocus)
 
         self.vbox = QtWidgets.QVBoxLayout()
         self.vbox.setContentsMargins(12, 12, 12, 12)
@@ -2220,7 +2220,7 @@ class NXPlotTab(QtWidgets.QWidget):
         self.name = name
         self.plotview = plotview
 
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         self.setMinimumHeight(51)
         hbox = QtWidgets.QHBoxLayout()
@@ -2366,6 +2366,7 @@ class NXPlotTab(QtWidgets.QWidget):
     def slider(self, slot):
         """Return a QSlider with a signal slot."""
         slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        slider.setFocusPolicy(QtCore.Qt.NoFocus)
         slider.setMinimumWidth(100)
         slider.setRange(0, 1000)
         slider.setSingleStep(5)
@@ -3103,8 +3104,6 @@ class NXProjectionTab(QtWidgets.QWidget):
         self.setTabOrder(self.sumbox, self.overplot_box)
         self.setTabOrder(self.overplot_box, self.panel_button)
 
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
-
     def __repr__(self):
         return 'NXProjectionTab("%s")' % self.plotview.label
 
@@ -3705,7 +3704,6 @@ class NXNavigationToolbar(NavigationToolbar):
         super(NXNavigationToolbar, self).__init__(canvas, parent)
         self.plotview = canvas.parent()
         self.zoom()
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
 
     def __repr__(self):
         return 'NXNavigationToolbar("%s")' % self.plotview.label

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2982,15 +2982,15 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
 
 class NXComboBox(QtWidgets.QComboBox):
 
-    def __init__(self, slot=None, items=[], name=None):
+    def __init__(self, slot=None, items=[], default=None):
         super(NXComboBox, self).__init__()
         self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setMinimumWidth(100)
         if items:
             self.addItems(items)
-            if name:
-                self.setCurrentIndex(self.findText(name))
+            if default:
+                self.setCurrentIndex(self.findText(default))
         if slot:
             self.activated.connect(slot)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -448,10 +448,16 @@ class NXPlotView(QtWidgets.QDialog):
         """
         if event.key == 'f':
             self.ztab.playforward()
+            self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ztab))
+            self.ztab.axiscombo.setFocus()
         elif event.key == 'b':
             self.ztab.playback()
+            self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ztab))
+            self.ztab.axiscombo.setFocus()
         elif event.key == ' ':
             self.ztab.pause()
+            self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.ztab))
+            self.ztab.axiscombo.setFocus()
         elif event.key == 'r':
             if self.ndim > 1:
                 self.replot_data()

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3426,6 +3426,8 @@ class NXProjectionPanel(QtWidgets.QWidget):
         self.update_limits()
         self.update_panels()
 
+        self.xbox.setFocus()
+
     def __repr__(self):
         return 'NXProjectionPanel("%s")' % self.plotview.label
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -344,7 +344,7 @@ class NXPlotView(QtWidgets.QDialog):
 
         # Remove some key default Matplotlib key mappings
         for key in [key for key in mpl.rcParams if key.startswith('keymap')]:
-            for shortcut in 'bfkloprsvxyzAEGOPSZ':
+            for shortcut in 'bfhkloprsvxyzAEGHOPSZ':
                 if shortcut in mpl.rcParams[key]:
                     mpl.rcParams[key].remove(shortcut)
 
@@ -446,13 +446,7 @@ class NXPlotView(QtWidgets.QDialog):
         The key that was pressed is stored in the Matplotlib KeyEvent 'key' 
         attribute.
         """
-        if event.key == 'l':
-            if self.ndim > 1:
-                if self.vtab.log:
-                    self.vtab.log = False
-                else:
-                    self.vtab.log = True
-        elif event.key == 'f':
+        if event.key == 'f':
             self.ztab.playforward()
         elif event.key == 'b':
             self.ztab.playback()
@@ -461,6 +455,14 @@ class NXPlotView(QtWidgets.QDialog):
         elif event.key == 'r':
             if self.ndim > 1:
                 self.replot_data()
+        elif event.key == 'h':
+            self.otab.home(autoscale=False)
+        elif event.key == 'l':
+            if self.ndim > 1:
+                if self.vtab.log:
+                    self.vtab.log = False
+                else:
+                    self.vtab.log = True
         elif event.key == 's' or event.key == 'v':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.vtab))
         elif event.key == 'x':
@@ -481,6 +483,8 @@ class NXPlotView(QtWidgets.QDialog):
             self.otab.add_data()
         elif event.key == 'E':
             self.otab.toggle_aspect()
+        elif event.key == 'H':
+            self.otab.home()
         elif event.key == 'G':
             self.grid()
         elif event.key == 'O':

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2668,7 +2668,7 @@ class NXPlotTab(QtWidgets.QWidget):
             idx = self.cmapcombo.findText(cmap)
             if idx < 0:
                 if cmap in cmap_d:
-                    self.cmapcombo.insertItem(4, cmap)
+                    self.cmapcombo.insertItem(5, cmap)
                     self.cmapcombo.setCurrentIndex(
                         self.cmapcombo.findText(cmap))
                 else:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3759,10 +3759,8 @@ class NXNavigationToolbar(NavigationToolbar):
 
     def _update_view(self):
         super(NXNavigationToolbar, self)._update_view()
-        lims = self._views()
-        if lims is None:
-            return
-        xmin, xmax, ymin, ymax = lims[0]
+        xmin, xmax = self.plotview.ax.get_xlim()
+        ymin, ymax = self.plotview.ax.get_ylim()
         if xmin > xmax:
             if self.plotview.xaxis.reversed:
                 self.plotview.xtab.flipped = False

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1240,17 +1240,21 @@ class NXPlotView(QtWidgets.QDialog):
                         vmin=None, vmax=None):
         """Set the minimum and maximum values of the plot."""
         if xmin is not None:
-            self.xaxis.min = xmin
+            self.xaxis.min = self.xaxis.lo = xmin
         if xmax is not None:
-            self.xaxis.max = xmax
+            self.xaxis.max = self.xaxis.hi = xmax
         if ymin is not None:
-            self.yaxis.min = ymin
+            self.yaxis.min = self.yaxis.lo = ymin
         if ymax is not None:
-            self.yaxis.max = ymax
+            self.yaxis.max = self.yaxis.hi = ymax
         if vmin is not None:
-            self.vaxis.min = vmin
+            self.vaxis.min = self.vaxis.lo = vmin
         if vmax is not None:
-            self.vaxis.max = vmax
+            self.vaxis.max = self.vaxis.hi = vmax
+        if self.ndim == 1:
+            self.replot_axes()
+        else:
+            self.replot_image()
         self.update_tabs()
 
     def reset_plot_limits(self, autoscale=True):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -345,7 +345,7 @@ class NXPlotView(QtWidgets.QDialog):
 
         # Remove some key default Matplotlib key mappings
         for key in [key for key in mpl.rcParams if key.startswith('keymap')]:
-            for shortcut in 'bfklopsvxyzAEGOPSZ':
+            for shortcut in 'bfkloprsvxyzAEGOPSZ':
                 if shortcut in mpl.rcParams[key]:
                     mpl.rcParams[key].remove(shortcut)
 
@@ -419,6 +419,8 @@ class NXPlotView(QtWidgets.QDialog):
             Toggle log scale (2D only).
         'f', 'b'
             Play the current z-axis values forward or backward, respectively.
+        'r'
+            Replot the image
         'A'
             Store the plotted data. This is equivalent to selecting the 
             `Add Data` option button on the toolbar.
@@ -458,6 +460,9 @@ class NXPlotView(QtWidgets.QDialog):
             self.ztab.playback()
         elif event.key == ' ':
             self.ztab.pause()
+        elif event.key == 'r':
+            if self.ndim > 1:
+                self.replot_data()
         elif event.key == 's' or event.key == 'v':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.vtab))
         elif event.key == 'x':

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -460,7 +460,6 @@ class NXPlotView(QtWidgets.QDialog):
             self.ztab.pause()
         elif event.key == 's' or event.key == 'v':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.vtab))
-            self.vtab.minbox.setFocus()
         elif event.key == 'x':
             self.tab_widget.setCurrentIndex(self.tab_widget.indexOf(self.xtab))
             self.xtab.axiscombo.setFocus()
@@ -1950,8 +1949,19 @@ class NXPlotView(QtWidgets.QDialog):
         self.update_customize_panel()
 
     def change_axis(self, tab, axis):
-        """Replace the axis in a plot tab."""
+        """Replace the axis in a plot tab.
+        
+        Parameters
+        ----------
+        tab : NXPlotTab
+            Tab containing the axis to be changed
+        axis : NXPlotAxis
+            Axis that replaces the current selection in the tab
+        """
         xmin, xmax, ymin, ymax = self.limits
+        if (tab == self.xtab and axis == self.xaxis or
+            tab == self.ytab and axis == self.yaxis):
+            return
         if tab == self.xtab and axis == self.yaxis:
             self.yaxis = self.ytab.axis = self.xtab.axis
             self.xaxis = self.xtab.axis = axis
@@ -2217,11 +2227,14 @@ class NXPlotTab(QtWidgets.QWidget):
         self.name = name
         self.plotview = plotview
 
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
         self.setMinimumHeight(51)
         hbox = QtWidgets.QHBoxLayout()
         widgets = []
 
         if axis:
+            self.axiscombo = NXComboBox(self.change_axis)
             widgets.append(self.axiscombo)
         else:
             self.axiscombo = None
@@ -3037,6 +3050,7 @@ class NXProjectionTab(QtWidgets.QWidget):
         self.sumbox = NXCheckBox("Sum", self.plotview.replot_data)
         widgets.append(self.sumbox)
 
+        self.overplot_box = NXCheckBox("Over")
         if 'Projection' not in plotviews:
             self.overplot_box.setVisible(False)
         widgets.append(self.overplot_box)
@@ -3678,6 +3692,7 @@ class NXNavigationToolbar(NavigationToolbar):
         super(NXNavigationToolbar, self).__init__(canvas, parent)
         self.plotview = canvas.parent()
         self.zoom()
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
 
     def __repr__(self):
         return 'NXNavigationToolbar("%s")' % self.plotview.label

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -260,7 +260,7 @@ class NXTreeView(QtWidgets.QTreeView):
         self.setSortingEnabled(True)
         self.sortByColumn(0, QtCore.Qt.AscendingOrder)
 
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         self.tree._item = self._model.invisibleRootItem()
         self.tree._item.node = self.tree


### PR DESCRIPTION
* Confines tab focus to within each plotting tab. The tree and shell panes can be given focus only with mouse clicks or keyboard shortcuts.
* Allows pull-down menus to be opened with a right-arrow key.
* Adds keyboard shortcuts for the z-axis movie controls.
* Adds fill values to the Initialize Data dialog.
* Fixes a bug in v0.10.6 with duplicate Ctrl+Shift+P shortcuts in non-Mac versions.
* Fixes a bug when reverting to a normal color map after a symmetric color map.
* Fixes a bug in the dialog box for setting plot limits.
* Fixes a bug that triggers an index error when the z-axis values are bin boundaries.
* Fixes an incompatibility with changes planned for Matplotlib v2.2.
