### PR TITLE
fix an order of the make_layout parameters

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -92,7 +92,7 @@ class BaseDialog(QtWidgets.QDialog):
                 self.layout.addWidget(item)
         self.setLayout(self.layout)
 
-    def make_layout(self, *items, horizontal=True):
+    def make_layout(self, horizontal=True, *items):
         if horizontal:
             layout = QtWidgets.QHBoxLayout()
             layout.addStretch()


### PR DESCRIPTION
I wanted to test the v0.10.11 but in order to run nexpy  I had to do the fix. Otherwise I get

    jkotan@haso228jk:~/sources/nexpy$ nexpy
    Traceback (most recent call last):
      File "/home/jkotan/testinst/bin/nexpy", line 11, in <module>
	load_entry_point('NeXpy==0.10.10+39.g9227249', 'gui_scripts', 'nexpy')()
      File "/home/jkotan/testinst/lib/python2.7/site-packages/NeXpy-0.10.10+39.g9227249-py2.7.egg/nexpy/nexpygui.py", line 24, in main
	from nexpy.gui.consoleapp import main
      File "/home/jkotan/testinst/lib/python2.7/site-packages/NeXpy-0.10.10+39.g9227249-py2.7.egg/nexpy/gui/consoleapp.py", line 33, in <module>
	from .mainwindow import MainWindow
      File "/home/jkotan/testinst/lib/python2.7/site-packages/NeXpy-0.10.10+39.g9227249-py2.7.egg/nexpy/gui/mainwindow.py", line 45, in <module>
	from .datadialogs import *
      File "/home/jkotan/testinst/lib/python2.7/site-packages/NeXpy-0.10.10+39.g9227249-py2.7.egg/nexpy/gui/datadialogs.py", line 95
	def make_layout(self, *items, horizontal=True):
					       ^
    SyntaxError: invalid syntax
