### PR TITLE
Ensure the NeXpy process is terminated on quit

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -366,6 +366,7 @@ def main(filename=None):
     app = NXConsoleApp()
     app.initialize(filename=filename)
     app.start()
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2191,6 +2191,8 @@ class MainWindow(QtWidgets.QMainWindow):
         if confirm_action("Are you sure you want to quit NeXpy?", 
                           icon=self.app.icon_pixmap):
             logging.info('NeXpy closed\n'+80*'-')
+            self.console.kernel_client.stop_channels()
+            self.console.kernel_manager.shutdown_kernel()
             self._app.closeAllWindows()
             self._app.quit()
             return event.accept()


### PR DESCRIPTION
There are reports that the NeXpy process is still running after a quit (#159). This adds two steps to the shutdown procedure.
* Explicitly stop the Jupyter console kernel.
* Calls sys.exit() after the QApplication has stopped.