### PR TITLE
Prepare release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup (name =  nexpy.__package_name__,        # NeXpy
                      'Programming Language :: Python :: 3.3',
                      'Programming Language :: Python :: 3.4',
                      'Programming Language :: Python :: 3.5',
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7',
                      'Topic :: Scientific/Engineering',
                      'Topic :: Scientific/Engineering :: Visualization'],
       )

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -324,9 +324,15 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         self.add_menu_action(self.file_menu, self.lockfile_action)
 
+        if sys.platform == 'darwin':
+            #This maps onto Cmd+U on a Mac. On other systems, this clashes with 
+            #the Ctrl+U command-line editing shortcut.
+            unlock_shortcut = QtGui.QKeySequence("Ctrl+U")
+        else:
+            unlock_shortcut = QtGui.QKeySequence("Ctrl+Shift+U")
         self.unlockfile_action=QtWidgets.QAction("&Unlock File",
             self,
-            shortcut=QtGui.QKeySequence("Ctrl+U"),
+            shortcut=unlock_shortcut,
             triggered=self.unlock_file
             )
         self.add_menu_action(self.file_menu, self.unlockfile_action)


### PR DESCRIPTION
* Prevents the `unlock` keyboard shortcut from interfering with the IPython shell `Ctrl+U` shortcut.
* Updates version numbers