### PR TITLE
Revert "Revert to using Matplotlib qt_compat module"

### DIFF
--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -9,13 +9,11 @@ try:
 except ImportError:
     pass
 
-from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 if QtCore.__name__.lower().startswith('pyqt5'):
     os.environ['QT_API'] = 'pyqt5'
     QtVersion = 'Qt5Agg'
 else:
-    QtCore.QSortFilterProxyModel = QtGui.QSortFilterProxyModel
-    QtCore.QItemSelectionModel = QtGui.QItemSelectionModel
     QtVersion = 'Qt4Agg'
     if QtCore.__name__.lower().startswith('pyqt4'):
         os.environ['QT_API'] = 'pyqt'


### PR DESCRIPTION
Reverts nexpy/nexpy#173

Instead of falling back to using `matplotlib.qt_compat` we should sort out what is wrong with the configuration of the user in #172 .