### PR TITLE
Use default interpolation if cached value unavailable

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2584,8 +2584,12 @@ class NXPlotTab(QtWidgets.QWidget):
         if self.name == 'v':
             self.interpcombo.clear()
             self.interpcombo.addItems(self.plotview.interpolations)
-            self.interpcombo.setCurrentIndex(
-                self.interpcombo.findText(self._cached_interpolation))
+            if self._cached_interpolation in self.plotview.interpolations:
+                self.interpcombo.setCurrentIndex(
+                    self.interpcombo.findText(self._cached_interpolation))
+            else:
+                self.interpcombo.setCurrentIndex(
+                    self.interpcombo.findText(default_interpolation))
         self.block_signals(False)
 
     def spinbox(self, slot):


### PR DESCRIPTION
Most interpolation schemes are only available for regularly gridded data. This prevents an exception when attempting to apply a cached interpolation to irregular data.