### PR TITLE
Override InProcessKernel _abort_queues function

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -130,7 +130,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if 'input_sep' not in self.config['JupyterWidget']:
             self.console.input_sep = ''
 
-        self.shell = self.console.kernel_manager.kernel.shell
+        self.kernel = self.console.kernel_manager.kernel
+        def _abort_queues(kernel):
+            pass
+        self.kernel._abort_queues = _abort_queues
+        self.shell = self.kernel.shell
         self.user_ns = self.console.kernel_manager.kernel.shell.user_ns
         self.shell.ask_exit = self.close
         self.shell._old_stb = self.shell._showtraceback


### PR DESCRIPTION
From v5.0.0 of the ipykernel package, there is a bug preventing use of the InProcessKernel class. This is fixed by overriding the _abort_queues function, which is not needed in the in-process kernel.