### PR TITLE
General Fixes

### DIFF
--- a/doc/source/pythonshell.rst
+++ b/doc/source/pythonshell.rst
@@ -3,8 +3,16 @@ Python Interface to NeXus
 *************************
 The Python interface to NeXus is provided by the `nexusformat 
 <https://github.com/nexpy/nexusformat>`_ package, which is distributed 
-separately from NeXpy. It can be used within a standard Python or IPython 
-shell:: 
+separately from NeXpy. 
+
+.. seealso:: The source code includes a 
+             `Jupyter notebook 
+             <https://github.com/nexpy/nexusformat/blob/master/src/nexusformat/notebooks/nexusformat.ipynb>`_ 
+             that provides a tutorial for the Python API. It can be run in
+             `Google Colaboratory 
+             <https://colab.research.google.com/github/nexpy/nexusformat/blob/master/src/nexusformat/notebooks/nexusformat.ipynb>`_.
+
+The Python API can be used within a standard Python or IPython shell:: 
 
  $ python
  Python 3.6.1 |Anaconda custom (x86_64)| (default, May 11 2017, 13:04:09) 
@@ -15,6 +23,7 @@ shell::
 .. note:: Although wildcard imports are usually discouraged in Python, there
           should not be any name clashes using it here because all the 
           imported functions and variables start with 'nx' or 'NX'.
+
 
 Loading NeXus Data
 ==================

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -761,8 +761,9 @@ class NXPanel(NXDialog):
 
     def close(self):
         tab = self.tab
-        tab.close()
-        self.remove(self.labels[tab])
+        if tab:
+            tab.close()
+            self.remove(self.labels[tab])
 
 
 class GridParameters(OrderedDict):

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -92,8 +92,10 @@ class NXWidget(QtWidgets.QWidget):
 
     def make_layout(self, *items, **opts):
         if 'vertical' in opts and opts['vertical'] == True:
+            vertical = True
             layout = QtWidgets.QVBoxLayout()
         else:
+            vertical = False
             layout = QtWidgets.QHBoxLayout()
             layout.addStretch()
         for item in items:

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2218,8 +2218,9 @@ class LimitTab(NXTab):
         self.minbox['signal'].setValue(self.plotview.axis['signal'].lo)
         self.maxbox['signal'].setValue(self.plotview.axis['signal'].hi)
         if self.plotview.label != 'Main':
-            self.parameters['xsize'].value = self.parameters['xsize'].init_value
-            self.parameters['ysize'].value = self.parameters['ysize'].init_value
+            figure_size = self.plotview.figure.get_size_inches()
+            self.parameters['xsize'].value = figure_size[0]
+            self.parameters['ysize'].value = figure_size[1]
         if self.ndim > 1:
             self.copied_properties = {'aspect': self.plotview.aspect,
                                       'cmap': self.plotview.cmap,

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2205,9 +2205,14 @@ class LimitTab(NXTab):
             self.ybox.setCurrentIndex(tab.ybox.currentIndex())
             for p in self.copied_properties:
                 self.copied_properties[p] = getattr(tab.plotview, p)
-        if self.plotview.label != 'Main' and tab.plotview.label != 'Main':
-            self.parameters['xsize'].value = tab.parameters['xsize'].value
-            self.parameters['ysize'].value = tab.parameters['ysize'].value
+        if self.plotview.label != 'Main':
+            if tab.plotview.label == 'Main':
+                figure_size = tab.plotview.figure.get_size_inches()
+                self.parameters['xsize'].value = figure_size[0]
+                self.parameters['ysize'].value = figure_size[1]
+            else:
+                self.parameters['xsize'].value = tab.parameters['xsize'].value
+                self.parameters['ysize'].value = tab.parameters['ysize'].value
 
     def reset(self):
         self.set_axes()

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -90,8 +90,8 @@ class NXWidget(QtWidgets.QWidget):
                 self.layout.addWidget(item)
         self.setLayout(self.layout)
 
-    def make_layout(self, *items, vertical=False):
-        if vertical:
+    def make_layout(self, *items, **opts):
+        if 'vertical' in opts and opts['vertical'] == True:
             layout = QtWidgets.QVBoxLayout()
         else:
             layout = QtWidgets.QHBoxLayout()

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -137,10 +137,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self.user_ns = self.console.kernel_manager.kernel.shell.user_ns
         self.shell.ask_exit = self.close
         self.shell._old_stb = self.shell._showtraceback
+        
         def new_stb(etype, evalue, stb):
             self.shell._old_stb(etype, evalue, [stb[-1]])
             self.shell._last_traceback = stb
         self.shell._showtraceback = new_stb
+
+        def enable_matplotlib(gui=None):
+            return
+        self.shell.enable_matplotlib = enable_matplotlib
 
         right_splitter = QtWidgets.QSplitter(rightpane)
         right_splitter.setOrientation(QtCore.Qt.Vertical)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -181,7 +181,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.init_menu_bar()
 
         self.file_filter = ';;'.join((
-            "NeXus Files (*.nxs *.nx5 *.h5 *.hdf *.hdf5 *.cxi)",
+            "NeXus Files (*.nxs *.nx5 *.nxspe *.h5 *.hdf *.hdf5 *.cxi)",
             "Any Files (*.* *)"))
         self.max_recent_files = 20
 
@@ -1079,7 +1079,8 @@ class MainWindow(QtWidgets.QMainWindow):
             nxfiles = sorted([f for f in os.listdir(directory) 
                               if ((f.endswith('.nxs') or f.endswith('.nx5') or
                                    f.endswith('.h5') or f.endswith('hdf5') or
-                                   f.endswith('hdf') or f.endswith('.cxi')) and
+                                   f.endswith('hdf') or f.endswith('.cxi') or
+                                   f.endswith('nxspe')) and
                               os.path.join(directory,f) not in tree_files and
                               not os.path.islink(os.path.join(directory,f)))],
                              key=natural_sort)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -143,10 +143,6 @@ class MainWindow(QtWidgets.QMainWindow):
             self.shell._last_traceback = stb
         self.shell._showtraceback = new_stb
 
-        def enable_matplotlib(gui=None):
-            return
-        self.shell.enable_matplotlib = enable_matplotlib
-
         right_splitter = QtWidgets.QSplitter(rightpane)
         right_splitter.setOrientation(QtCore.Qt.Vertical)
         right_splitter.addWidget(main_plotview)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -875,7 +875,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.script_menu.addSeparator()
 
         self.scripts = {}
-        files = os.listdir(self.script_dir)
+        files = sorted(os.listdir(self.script_dir))
         for file_name in files:
             if file_name.endswith('.py'):
                 self.add_script_action(os.path.join(self.script_dir, file_name))

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1931,9 +1931,11 @@ class MainWindow(QtWidgets.QMainWindow):
                 before_action = self.active_action[num]
             self.active_action[number] = QtWidgets.QAction(label,
                 self,
-                shortcut=QtGui.QKeySequence("Ctrl+%s" % number),
                 triggered=lambda: self.make_active(number),
                 checkable=True)
+            if number < 10:
+                self.active_action[number].setShortcut(
+                    QtGui.QKeySequence("Ctrl+%s" % number))
             self.window_menu.insertAction(before_action,
                                           self.active_action[number])
         self.make_active(number)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2010,10 +2010,8 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             if self.log_window:
                 self.log_window.show_log()
-                self.log_window.raise_()
             else:
                 self.log_window = LogDialog(parent=self)
-                self.log_window.show()
         except NeXusError as error:
             report_error("Showing Log File", error)
 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -830,7 +830,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.closewindow_action=QtWidgets.QAction("Close Plot Window",
             self,
-            shortcut=QtGui.QKeySequence("Ctrl+Shift+W"),
+            shortcut=QtGui.QKeySequence("Ctrl+W"),
             triggered=self.close_window
             )
         self.add_menu_action(self.window_menu, self.closewindow_action,)
@@ -1944,8 +1944,9 @@ class MainWindow(QtWidgets.QMainWindow):
         new_plotview = NXPlotView(parent=self)
 
     def close_window(self):
-        if self.plotview.number != 1:
-            self.plotview.close()
+        for w in [w for w in self.app.app.topLevelWidgets() if w.isActiveWindow()]:
+            w.close()
+            break
 
     def equalize_windows(self):
         for label in [label for label in self.plotviews 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013, NeXpy Development Team.
+# Copyright (c) 2013-2019, NeXpy Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -895,6 +895,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self,
             triggered=self._open_nexpy_online_help)
         self.add_menu_action(self.help_menu, self.nexpyHelpAct)
+
+        self.notebookHelpAct = QtWidgets.QAction("Open NeXus API Tutorial Online",
+            self,
+            triggered=self._open_nexusformat_online_notebook)
+        self.add_menu_action(self.help_menu, self.notebookHelpAct)
 
         self.nexusHelpAct = QtWidgets.QAction(
             "Open NeXus Base Class Definitions Online",
@@ -2081,15 +2086,20 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.script_menu.removeAction(action)
 
     def _open_nexpy_online_help(self):
-        filename = "http://nexpy.github.io/nexpy/"
+        filename = "https://nexpy.github.io/nexpy/"
+        webbrowser.open(filename, new=1, autoraise=True)
+
+    def _open_nexusformat_online_notebook(self):
+        filename = ("https://colab.research.google.com/github/nexpy/nexusformat/blob/" +
+                    "master/src/nexusformat/notebooks/nexusformat.ipynb")
         webbrowser.open(filename, new=1, autoraise=True)
 
     def _open_nexus_online_help(self):
-        filename = "http://download.nexusformat.org/doc/html/classes/base_classes/"
+        filename = "https://download.nexusformat.org/doc/html/classes/base_classes/"
         webbrowser.open(filename, new=1, autoraise=True)
 
     def _open_ipython_online_help(self):
-        filename = "http://ipython.org/ipython-doc/stable/index.html"
+        filename = "https://ipython.org/ipython-doc/stable/index.html"
         webbrowser.open(filename, new=1, autoraise=True)
 
     def open_example_file(self):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1972,8 +1972,6 @@ class MainWindow(QtWidgets.QMainWindow):
             if 'limit' not in self.panels:
                 self.panels['limit'] = LimitDialog(parent=self)
             self.panels['limit'].activate(self.plotview.label)
-            self.panels['limit'].setVisible(True)
-            self.panels['limit'].raise_()
         except NeXusError as error:
             report_error("Changing Plot Limits", error)
 
@@ -1988,8 +1986,6 @@ class MainWindow(QtWidgets.QMainWindow):
             if 'customize' not in self.panels:
                 self.panels['customize'] = CustomizeDialog(parent=self)
             self.panels['customize'].activate(self.plotview.label)
-            self.panels['customize'].setVisible(True)
-            self.panels['customize'].raise_()
         except NeXusError as error:
             report_error("Customizing Plot", error)
 
@@ -2030,8 +2026,6 @@ class MainWindow(QtWidgets.QMainWindow):
             if 'projection' not in self.panels:
                 self.panels['projection'] = ProjectionDialog(parent=self)
             self.panels['projection'].activate(self.plotview.label)
-            self.panels['projection'].setVisible(True)
-            self.panels['projection'].raise_()
         except NeXusError as error:
             report_error("Showing Projection Panel", error)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1006,11 +1006,14 @@ class NXPlotView(QtWidgets.QDialog):
         ax.set_aspect(self.aspect)
 
         if not over and not self.rgb_image:
-            self.colorbar = self.figure.colorbar(self.image, ax=ax, 
-                                                 norm=self.norm)
+            self.colorbar = self.figure.colorbar(self.image, ax=ax)
             self.colorbar.locator = self.locator
             self.colorbar.formatter = self.formatter
-            self.colorbar.update_bruteforce(self.image)
+            if mpl.__version__ >= '3.1.0':
+                self.colorbar.update_normal(self.image)
+            else:
+                self.colorbar.set_norm(self.norm)
+                self.colorbar.update_bruteforce(self.image)
 
         xlo, ylo = self.transform(self.xaxis.lo, self.yaxis.lo)
         xhi, yhi = self.transform(self.xaxis.hi, self.yaxis.hi)
@@ -1172,8 +1175,11 @@ class NXPlotView(QtWidgets.QDialog):
             if self.colorbar:
                 self.colorbar.locator = self.locator
                 self.colorbar.formatter = self.formatter
-                self.colorbar.set_norm(self.norm)
-                self.colorbar.update_bruteforce(self.image)
+                if mpl.__version__ >= '3.1.0':
+                    self.colorbar.update_normal(self.image)
+                else:
+                    self.colorbar.set_norm(self.norm)
+                    self.colorbar.update_bruteforce(self.image)
             self.image.set_clim(self.vaxis.lo, self.vaxis.hi)
             if self.regular_grid:
                 if self.interpolation == 'convolve':

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -31,7 +31,6 @@ import warnings
 from posixpath import dirname, basename
 
 import matplotlib as mpl
-from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 if QtVersion == 'Qt5Agg':
     from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
@@ -112,20 +111,19 @@ def new_figure_manager(label=None, *args, **kwargs):
     label : str
         The label used to define 
     """
-    import matplotlib.pyplot as plt
+    global plotviews
     if label is None:
         label = ''
     if label == 'Projection' or label == 'Fit':
-        nums = [num for num in plt.get_fignums() if num > 100]
+        nums = [plotviews[p].number for p in plotviews if plotviews[p].number > 100]
         if nums:
             num = max(nums) + 1
         else:
             num = 101
     else:
-        nums = [num for num in plt.get_fignums() if num < 100]
+        nums = [plotviews[p].number for p in plotviews if plotviews[p].number < 100]
         if nums:
-            missing_nums = sorted(set(range(nums[0], 
-                                  nums[-1]+1)).difference(nums))
+            missing_nums = sorted(set(range(nums[0], nums[-1]+1)).difference(nums))
             if missing_nums:
                 num = missing_nums[0]
             else:
@@ -286,7 +284,6 @@ class NXPlotView(QtWidgets.QDialog):
         self.canvas.setFocusPolicy(QtCore.Qt.ClickFocus)
         self.canvas.callbacks.exception_handler = report_exception
 
-        Gcf.set_active(self.figuremanager)
         self.mpl_connect = self.canvas.mpl_connect
         self.button_press_cid = self.mpl_connect('button_press_event', 
                                                  self.on_button_press)
@@ -561,7 +558,6 @@ class NXPlotView(QtWidgets.QDialog):
         if self.number < 101:
             plotview = self
             self.mainwindow.user_ns['plotview'] = self
-        Gcf.set_active(self.figuremanager)
         self.show()
         if self.label == 'Main':
             self.mainwindow.raise_()
@@ -2284,7 +2280,6 @@ class NXPlotView(QtWidgets.QDialog):
     def close_view(self):
         """Remove this window from menus and close associated panels."""
         self.remove_menu_action()
-        Gcf.destroy(self.number)
         if self.label in plotviews:
             del plotviews[self.label]
         for panel in self.panels:

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -685,7 +685,8 @@ class NXcircle(NXpatch):
     def initialize(self, xp, yp):
         x0, y0 = self.circle.center
         w0, h0 = self.width, self.height
-        xt, yt, rt = *self.pixel_shift(xp, yp, x0, y0), self.pixel_radius
+        xt, yt = self.pixel_shift(xp, yp, x0, y0)
+        rt = self.pixel_radius
         if (self.allow_resize and
             (np.sqrt(xt**2 + yt**2) > rt * (1-self.border_tol))):
             expand = True


### PR DESCRIPTION
* Fixes an issue with reading the window size when using the LimitDialog reset button
* Allows the MainWindow plotting window size to be copied in the LimitDialog
* Removes registration of NXPlotView figure managers with `pyplot` to improve compatibility with Matplotlib v3.1.0
* Fixes the colorbar normalization when using Matplotlib v3.1.0
* Allows windows (or tabs in NXPanels) to be closed with `Ctrl+W`
* Improves consistency of activating windows and tabs using menus or keyboard shortcuts
* Sorts the menu listing of NeXpy scripts
* Adds `.nxspe` to the list of standard NeXus file extensions
* Adds a link in the Help menu to an online Jupyter Notebook tutorial for the `nexusformat` API.