### PR TITLE
Catch exceptions to setting default axes

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1131,9 +1131,9 @@ class PlotDialog(NXDialog):
             self.group = node
             signal_name = None
         
-        if self.group.nxaxes is not None:
+        try:
             self.default_axes = [axis.nxname for axis in self.group.nxaxes]
-        else:
+        except Exception:
             self.default_axes = []
 
         self.fmt = fmt


### PR DESCRIPTION
* This ensures that the PlotDialog works when attempts to set default axes using the `nxaxes` property triggers an exception. This is usually because the axes are improperly defined in the NeXus file, _e.g._, they do not match the dimensions of the signal.