### PR TITLE
Add file-based locks

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -3180,23 +3180,12 @@ class UnlockDialog(NXDialog):
         self.setWindowTitle("Unlock File")
         self.node = node
 
-        default = False
-        if self.node.exists():
-            file_size = os.path.getsize(self.node.nxfilename)
-            if file_size < 10000000:
-                default = True
+        file_size = os.path.getsize(self.node.nxfilename)
+        if file_size < 10000000:
+            default = True
         else:
-            self.node.unlock()
-            raise NeXusError("'%s' does not exist" % 
-                             os.path.abspath(self.nxfilename))
-        nxfile = self.node.nxfile
-        if nxfile.is_locked():
-            lock_time = modification_time(nxfile.lock_file)
-            if self.confirm_action("File already locked. Do you want to clear the lock?",
-                                   "Lock file created: "+lock_time, answer="no"):
-                nxfile.release_lock()
-            else:
-                self.reject()
+            default = False
+
         self.set_layout(self.labels(
                             "<b>Are you sure you want to unlock the file?</b>"),
                         self.checkboxes(('backup', 'Backup file (%s)' 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -38,7 +38,7 @@ except ImportError:
 from .utils import (confirm_action, display_message, report_error,
                     import_plugin, convertHTML, natural_sort, wrap, human_size,
                     timestamp, format_timestamp, restore_timestamp, get_color,
-                    keep_data, fix_projection)
+                    keep_data, fix_projection, modification_time)
 from .widgets import (NXCheckBox, NXComboBox, NXColorBox, NXPushButton, NXStack,
                       NXDoubleSpinBox, NXSpinBox, NXpolygon)
 
@@ -3189,6 +3189,14 @@ class UnlockDialog(NXDialog):
             self.node.unlock()
             raise NeXusError("'%s' does not exist" % 
                              os.path.abspath(self.nxfilename))
+        nxfile = self.node.nxfile
+        if nxfile.is_locked():
+            lock_time = modification_time(nxfile.lock_file)
+            if self.confirm_action("File already locked. Do you want to clear the lock?",
+                                   "Lock file created: "+lock_time, answer="no"):
+                nxfile.release_lock()
+            else:
+                self.reject()
         self.set_layout(self.labels(
                             "<b>Are you sure you want to unlock the file?</b>"),
                         self.checkboxes(('backup', 'Backup file (%s)' 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1002,6 +1002,10 @@ class MainWindow(QtWidgets.QMainWindow):
             fname = getOpenFileName(self, 'Open File (Read Only)',
                                     self.default_directory,  self.file_filter)
             if fname:
+                if self.file_locked(fname):
+                    logging.info("NeXus file '%s' is locked by an external process."
+                                 % fname)
+                    return
                 name = self.tree.get_name(fname)
                 self.tree[name] = nxload(fname)
                 self.treeview.select_node(self.tree[name])
@@ -1018,6 +1022,8 @@ class MainWindow(QtWidgets.QMainWindow):
             fname = getOpenFileName(self, 'Open File (Read/Write)',
                                     self.default_directory, self.file_filter)
             if fname:
+                if self.file_locked(fname):
+                    return
                 name = self.tree.get_name(fname)
                 self.tree[name] = nxload(fname, 'rw')
                 self.treeview.select_node(self.tree[name])
@@ -1035,6 +1041,8 @@ class MainWindow(QtWidgets.QMainWindow):
             fname = self.recent_file_actions[self.sender()][1]
             if not os.path.exists(fname):
                 raise NeXusError("%s does not exist" % fname)
+            elif self.file_locked(fname):
+                return
             name = self.tree.get_name(fname)
             self.tree[name] = nxload(fname)
             self.treeview.select_node(self.tree[name])
@@ -1090,6 +1098,8 @@ class MainWindow(QtWidgets.QMainWindow):
                               '\n'.join(nxfiles)):
                 for nxfile in nxfiles:
                     fname = os.path.join(directory, nxfile)
+                    if self.file_locked(fname, wait=1):
+                        continue
                     name = self.tree.get_name(fname)
                     self.tree[name] = nxload(fname)
                 self.treeview.select_node(self.tree[name])
@@ -1174,6 +1184,8 @@ class MainWindow(QtWidgets.QMainWindow):
                     fname = getSaveFileName(self, "Choose a Filename",
                                             default_name, self.file_filter)
                     if fname:
+                        if self.file_locked(fname):
+                            return
                         with NXFile(fname, 'w') as f:
                             f.copyfile(node.nxfile)
                         name = self.tree.get_name(fname)
@@ -1205,11 +1217,13 @@ class MainWindow(QtWidgets.QMainWindow):
             node = self.treeview.get_node()
             if not node.file_exists():
                 raise NeXusError("%s does not exist" % node.nxfilename)
+            elif self.nodefile_locked(node):
+                return
             path = node.nxpath
             root = node.nxroot
             name = root.nxname
             if confirm_action("Are you sure you want to reload '%s'?" % name):
-                self.tree.reload(name)
+                root.reload()
                 logging.info("Workspace '%s' reloaded" % name)
                 try:
                     self.treeview.select_node(self.tree[name][path])
@@ -1281,14 +1295,41 @@ class MainWindow(QtWidgets.QMainWindow):
     def unlock_file(self):
         try:
             node = self.treeview.get_node()
-            if isinstance(node, NXroot) and node.nxfilemode:
-                dialog = UnlockDialog(node, parent=self)
-                dialog.show()
-                self.treeview.update()
-            else:
+            if not (isinstance(node, NXroot) and node.nxfilemode):
                 raise NeXusError("Can only unlock a saved NXroot group")
+            elif not node.file_exists():
+                raise NeXusError("'%s' does not exist" % node.nfilename)
+            elif node.is_modified():
+                if confirm_action("File has been modified. Reload?"):
+                    node.reload()
+                else:
+                    return
+            elif self.nodefile_locked(node):
+                return
+            dialog = UnlockDialog(node, parent=self)
+            dialog.show()
+            self.treeview.update()
         except NeXusError as error:
             report_error("Unlocking File", error)
+
+    def nodefile_locked(self, node):
+        return self.file_locked(node.nxfile.filename)
+
+    def file_locked(self, filename, wait=10):
+        _lock = NXLock(filename)
+        try:
+            _lock.wait(wait)
+            return False
+        except NXLockException:
+            lock_time = modification_time(_lock.lock_file)
+            if confirm_action("File locked. Do you want to clear the lock?",
+                              "%s\nLock file created: "%filename+lock_time, answer="no"):
+                _lock.clear()
+                return False
+            else:
+                return True           
+        else:
+            return False
 
     def backup_file(self):
         try:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -59,7 +59,7 @@ from mpl_toolkits.axisartist import Subplot
 from mpl_toolkits.axisartist.grid_finder import MaxNLocator
 from scipy.spatial import Voronoi, voronoi_plot_2d
 
-from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError, nxload
+from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError
 
 from .. import __version__
 from .widgets import (NXSpinBox, NXDoubleSpinBox, NXComboBox, NXCheckBox, NXPushButton,

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -319,9 +319,10 @@ def is_timestamp(time_string):
 
 def modification_time(filename):
     try:
-        return datetime.datetime.fromtimestamp(os.path.getmtime(filename))
+        _mtime = os.path.getmtime(filename)
+        return datetime.fromtimestamp(_mtime).strftime("%Y-%m-%d %H:%M:%S")
     except FileNotFoundError:
-        return None
+        return ''
 
 
 def convertHTML(text):


### PR DESCRIPTION
* Integrates the new `nexusformat` file-based locking system into the NeXpy GUI.
* Opening, reloading and unlocking files checks for existing locks, allowing stale locks to be cleared.
* Forces the reloading of trees in files modified by external processes before unlocking a file.