### PR TITLE
New features

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1403,7 +1403,7 @@ class PlotScalarDialog(NXDialog):
         
         self.signal_combo =  NXComboBox()
         signals = [s for s in self.group if self.group[s].size == 1 and 
-                                            not self.group[s].is_string()]
+                                            self.group[s].is_numeric()]
         if len(signals) == 0:
             raise NeXusError("No numeric scalars in group")
         self.signal_combo.add(*signals)

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1733,8 +1733,8 @@ class ProjectionTab(NXTab):
         self.lockbox = {}
         for axis in range(self.ndim):
             row += 1
-            self.minbox[axis] = self.spinbox()
-            self.maxbox[axis] = self.spinbox()
+            self.minbox[axis] = NXSpinBox(self.set_limits)
+            self.maxbox[axis] = NXSpinBox(self.set_limits)
             self.lockbox[axis] = NXCheckBox(slot=self.set_lock)
             grid.addWidget(self.label(self.plotview.axis[axis].name), row, 0)
             grid.addWidget(self.minbox[axis], row, 1)
@@ -1767,9 +1767,7 @@ class ProjectionTab(NXTab):
         self.checkbox["hide"].stateChanged.connect(self.hide_rectangle)
 
         self.initialize()
-
         self._rectangle = None
-
         self.xbox.setFocus()
 
     def __repr__(self):
@@ -1984,15 +1982,6 @@ class ProjectionTab(NXTab):
         except NeXusError as error:
             report_error("Masking Data", error)
 
-    def spinbox(self):
-        spinbox = NXSpinBox()
-        spinbox.setAlignment(QtCore.Qt.AlignRight)
-        spinbox.setFixedWidth(100)
-        spinbox.setKeyboardTracking(False)
-        spinbox.setAccelerated(True)
-        spinbox.valueChanged[six.text_type].connect(self.set_limits)
-        return spinbox
-
     def block_signals(self, block=True):
         for axis in range(self.ndim):
             self.minbox[axis].blockSignals(block)
@@ -2159,8 +2148,8 @@ class LimitTab(NXTab):
         self.lockbox = {}
         for axis in range(self.ndim):
             row += 1
-            self.minbox[axis] = self.spinbox()
-            self.maxbox[axis] = self.spinbox()
+            self.minbox[axis] = NXSpinBox(self.set_limits)
+            self.maxbox[axis] = NXSpinBox(self.set_limits)
             self.lockbox[axis] = NXCheckBox(slot=self.set_lock)
             grid.addWidget(self.label(self.plotview.axis[axis].name), row, 0)
             grid.addWidget(self.minbox[axis], row, 1)
@@ -2299,15 +2288,6 @@ class LimitTab(NXTab):
             else:
                 self.minbox[axis].diff = self.maxbox[axis].diff = None
                 self.minbox[axis].setDisabled(False)
-
-    def spinbox(self):
-        spinbox = NXSpinBox()
-        spinbox.setAlignment(QtCore.Qt.AlignRight)
-        spinbox.setFixedWidth(100)
-        spinbox.setKeyboardTracking(False)
-        spinbox.setAccelerated(True)
-        spinbox.valueChanged[six.text_type].connect(self.set_limits)
-        return spinbox
 
     def block_signals(self, block=True):
         for axis in range(self.ndim):
@@ -2502,8 +2482,8 @@ class ScanTab(NXTab):
         self.lockbox = {}
         for axis in range(self.ndim):
             row += 1
-            self.minbox[axis] = self.spinbox()
-            self.maxbox[axis] = self.spinbox()
+            self.minbox[axis] = NXSpinBox(self.set_limits)
+            self.maxbox[axis] = NXSpinBox(self.set_limits)
             self.lockbox[axis] = NXCheckBox(slot=self.set_lock)
             grid.addWidget(self.label(self.plotview.axis[axis].name), row, 0)
             grid.addWidget(self.minbox[axis], row, 1)
@@ -2804,15 +2784,6 @@ class ScanTab(NXTab):
         else:
             from .plotview import NXPlotView
             return NXPlotView('Scan')
-
-    def spinbox(self):
-        spinbox = NXSpinBox()
-        spinbox.setAlignment(QtCore.Qt.AlignRight)
-        spinbox.setFixedWidth(100)
-        spinbox.setKeyboardTracking(False)
-        spinbox.setAccelerated(True)
-        spinbox.valueChanged[six.text_type].connect(self.set_limits)
-        return spinbox
 
     def block_signals(self, block=True):
         for axis in range(self.ndim):

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2109,8 +2109,16 @@ class ProjectionTab(NXTab):
     def reset(self):
         self.block_signals(True)
         for axis in range(self.ndim):
-            self.minbox[axis].setValue(self.minbox[axis].data.min())
-            self.maxbox[axis].setValue(self.maxbox[axis].data.max())
+            if (self.plotview.axis[axis] is self.plotview.xaxis or 
+                   self.plotview.axis[axis] is self.plotview.yaxis):
+                self.minbox[axis].setValue(self.minbox[axis].data.min())
+                self.maxbox[axis].setValue(self.maxbox[axis].data.max())
+            else:
+                lo, hi = self.plotview.axis[axis].get_limits()
+                minbox, maxbox = self.minbox[axis], self.maxbox[axis]
+                ilo, ihi = minbox.indexFromValue(lo), maxbox.indexFromValue(hi)
+                minbox.setValue(minbox.valueFromIndex(ilo))
+                maxbox.setValue(maxbox.valueFromIndex(ihi))
         self.block_signals(False)
         self.update()
 
@@ -2902,8 +2910,16 @@ class ScanTab(NXTab):
     def reset(self):
         self.block_signals(True)
         for axis in range(self.ndim):
-            self.minbox[axis].setValue(self.minbox[axis].data.min())
-            self.maxbox[axis].setValue(self.maxbox[axis].data.max())
+            if (self.plotview.axis[axis] is self.plotview.xaxis or 
+                   self.plotview.axis[axis] is self.plotview.yaxis):
+                self.minbox[axis].setValue(self.minbox[axis].data.min())
+                self.maxbox[axis].setValue(self.maxbox[axis].data.max())
+            else:
+                lo, hi = self.plotview.axis[axis].get_limits()
+                minbox, maxbox = self.minbox[axis], self.maxbox[axis]
+                ilo, ihi = minbox.indexFromValue(lo), maxbox.indexFromValue(hi)
+                minbox.setValue(minbox.valueFromIndex(ilo))
+                maxbox.setValue(maxbox.valueFromIndex(ihi))
         self.block_signals(False)
         self.update()
 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2829,7 +2829,7 @@ class ScanTab(NXTab):
             self._rectangle = NXpolygon(self.get_rectangle(), closed=True).shape
             self._rectangle.set_edgecolor(self.plotview._gridcolor)
             self._rectangle.set_facecolor('none')
-            self._rectangle.set_linestyle('dashed')
+            self._rectangle.set_linestyle('dotted')
             self._rectangle.set_linewidth(2)
         return self._rectangle
 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2548,7 +2548,10 @@ class ScanTab(NXTab):
                                         ("lines", "Plot Lines", False),
                                         ("hide", "Hide Limits", False)),
                         self.copy_layout("Copy Limits"))
-        self.checkbox["hide"].stateChanged.connect(self.hide_rectangle)
+        if self.ndim == 1:
+            self.checkbox["hide"].setVisible(False)
+        else:
+            self.checkbox["hide"].stateChanged.connect(self.hide_rectangle)
 
         self.initialize()
         self._rectangle = None
@@ -2852,8 +2855,9 @@ class ScanTab(NXTab):
             return xy
 
     def draw_rectangle(self):
-        self.rectangle.set_xy(self.get_rectangle())
-        self.plotview.draw()
+        if self.ndim > 1:
+            self.rectangle.set_xy(self.get_rectangle())
+            self.plotview.draw()
 
     def rectangle_visible(self):
         return not self.checkbox["hide"].isChecked()

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2302,6 +2302,10 @@ class ProjectionTab(NXTab):
         self.xbox.setCurrentIndex(tab.xbox.currentIndex())
         if self.ndim > 1:
             self.ybox.setCurrentIndex(tab.ybox.currentIndex())
+        if self.plot and self.plot.ndim == 1 and self.yaxis == 'None':
+            self.overplot_box.setVisible(True)
+        else:
+            self.overplot_box.setVisible(False)
         self.block_signals(False)
         self.draw_rectangle()              
 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2633,6 +2633,7 @@ class ScanTab(NXTab):
         self.file_box = NXDialog()
         self.file_box.setWindowTitle('Select Files')
         self.file_box.setMinimumWidth(300)
+        scroll_area = QtWidgets.QScrollArea()
         self.files = GridParameters()
         i = 0
         for name in sorted(self.tree, key=natural_sort):
@@ -2641,9 +2642,12 @@ class ScanTab(NXTab):
                 root[self.data_path].nxsignal.exists()):
                 i += 1
                 self.files.add(name, root[self.scan_path], name, vary=True)
-        self.file_box.set_layout(
-            self.files.grid(header=('File', self.scan_variable.nxname, '')),
-            self.file_box.close_layout(close=True))
+        scroll_widget = NXWidget()
+        scroll_widget.set_layout(
+            self.files.grid(header=('File', self.scan_variable.nxname, '')))
+        scroll_area.setWidget(scroll_widget)
+        self.file_box.set_layout(scroll_area, 
+                                 self.file_box.close_layout(close=True))
         self.file_box.show()
 
     def get_axes(self):

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2082,9 +2082,6 @@ class ProjectionTab(NXTab):
                     minbox.setValue(minbox.valueFromIndex(ilo))
                 if  hi < maxbox.value():
                     maxbox.setValue(maxbox.valueFromIndex(ihi))
-            else:
-                minbox.setValue(minbox.valueFromIndex(ilo))
-                maxbox.setValue(maxbox.valueFromIndex(ihi))
         self.block_signals(False)
         self.draw_rectangle()
         self.sort_copybox()
@@ -2883,9 +2880,6 @@ class ScanTab(NXTab):
                     minbox.setValue(minbox.valueFromIndex(ilo))
                 if  hi < maxbox.value():
                     maxbox.setValue(maxbox.valueFromIndex(ihi))
-            else:
-                minbox.setValue(minbox.valueFromIndex(ilo))
-                maxbox.setValue(maxbox.valueFromIndex(ihi))
         self.block_signals(False)
         self.draw_rectangle()
         self.sort_copybox()

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1190,7 +1190,11 @@ class DirectoryDialog(NXDialog):
             self.checkbox[f] = NXCheckBox(checked=True)
             grid.addWidget(NXLabel(f), i, 0)
             grid.addWidget(self.checkbox[f], i, 1)
-        self.set_layout(self.make_layout(grid), self.close_layout())
+        scroll_widget = NXWidget()
+        scroll_widget.set_layout(grid)
+        scroll_area = QtWidgets.QScrollArea()
+        scroll_area.setWidget(scroll_widget)
+        self.set_layout(self.make_layout(scroll_area), self.close_layout())
 
     @property
     def files(self):

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -592,6 +592,7 @@ class NXDialog(QtWidgets.QDialog, NXWidget):
     def __init__(self, parent=None, default=False):
         QtWidgets.QDialog.__init__(self, parent)
         NXWidget.__init__(self, parent)
+        self.setSizeGripEnabled(True)
         self.mainwindow.current_dialog = self
         if not default:
             self.installEventFilter(self)
@@ -1221,8 +1222,6 @@ class PlotDialog(NXDialog):
         self.setLayout(self.layout)
 
         self.setWindowTitle("Plot NeXus Data")
-
-
 
     @property
     def signal(self):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1467,7 +1467,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     dialog = PlotDialog(node, parent=self)
                     dialog.show()
                 elif (isinstance(node, NXfield) and 
-                      node.size == 1 and not node.is_string()):
+                      node.size == 1 and node.is_numeric()):
                     dialog = PlotScalarDialog(node, parent=self)
                     dialog.show()
                 else:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1132,19 +1132,8 @@ class MainWindow(QtWidgets.QMainWindow):
                              key=natural_sort)
             if len(nxfiles) == 0:
                 raise NeXusError("No NeXus files found in directory")
-            if confirm_action("Open %s NeXus files" % len(nxfiles),
-                              '\n'.join(nxfiles)):
-                for nxfile in nxfiles:
-                    fname = os.path.join(directory, nxfile)
-                    if is_file_locked(fname, wait=1):
-                        continue
-                    name = self.tree.get_name(fname)
-                    self.tree[name] = nxload(fname)
-                self.treeview.select_node(self.tree[name])
-                self.treeview.setFocus()
-                self.default_directory = os.path.dirname(fname)
-                logging.info(
-                    "%s NeXus files opened from %s" % (len(nxfiles), directory))
+            dialog = DirectoryDialog(nxfiles, directory)
+            dialog.show()
         except NeXusError as error:
             report_error("Opening Directory", error)
 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1466,6 +1466,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 elif node.is_plottable():
                     dialog = PlotDialog(node, parent=self)
                     dialog.show()
+                elif (isinstance(node, NXfield) and 
+                      node.size == 1 and not node.is_string()):
+                    dialog = PlotScalarDialog(node, parent=self)
+                    dialog.show()
                 else:
                     raise NeXusError("Data not plottable")
         except NeXusError as error:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2140,7 +2140,7 @@ class MainWindow(QtWidgets.QMainWindow):
             report_error("Showing Projection Panel", error)
 
     def show_scan_panel(self):
-        if self.plotview.label == 'Projection' or self.plotview.ndim == 1:
+        if self.plotview.label == 'Projection':
             return
         try:
             if 'scan' not in self.panels:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -63,8 +63,8 @@ from scipy.spatial import Voronoi, voronoi_plot_2d
 from nexusformat.nexus import NXfield, NXdata, NXroot, NeXusError
 
 from .. import __version__
-from .widgets import (NXSpinBox, NXDoubleSpinBox, NXComboBox, NXCheckBox, 
-                      NXLabel, NXPushButton,
+from .widgets import (NXSpinBox, NXDoubleSpinBox, NXSlider, NXComboBox, 
+                      NXCheckBox, NXLabel, NXPushButton,
                       NXcircle, NXellipse, NXrectangle, NXpolygon)
 from .utils import (report_error, report_exception, boundaries, centers, keep_data, 
                     fix_projection, find_nearest, iterable)
@@ -2575,8 +2575,8 @@ class NXPlotTab(QtWidgets.QWidget):
             self.axiscombo = None
         if zaxis:
             self.zaxis = True
-            self.minbox = self.spinbox(self.read_minbox)
-            self.maxbox = self.spinbox(self.read_maxbox)
+            self.minbox = NXSpinBox(self.read_minbox)
+            self.maxbox = NXSpinBox(self.read_maxbox)
             self.lockbox = NXCheckBox("Lock", self.change_lock)
             self.lockbox.setChecked(True)
             self.scalebox = NXCheckBox("Autoscale", self.plotview.replot_image)
@@ -2593,10 +2593,14 @@ class NXPlotTab(QtWidgets.QWidget):
             self.zaxis = False
             self.plotcombo = NXComboBox(self.select_plot, ['0'])
             self.plotcombo.setMinimumWidth(20)
-            self.minbox = self.doublespinbox(self.read_minbox)
-            self.minslider = self.slider(self.read_minslider)
-            self.maxslider = self.slider(self.read_maxslider)
-            self.maxbox = self.doublespinbox(self.read_maxbox)
+            self.minbox = NXDoubleSpinBox(self.read_minbox)
+            if self.name == 'v':
+                self.minslider = NXSlider(self.read_minslider, move=False)
+                self.maxslider = NXSlider(self.read_maxslider, move=False)
+            else:
+                self.minslider = NXSlider(self.read_minslider)
+                self.maxslider = NXSlider(self.read_maxslider)
+            self.maxbox = NXDoubleSpinBox(self.read_maxbox)
             if log:
                 self.logbox = NXCheckBox("Log", self.change_log)
                 self.logbox.setChecked(False)
@@ -2709,39 +2713,6 @@ class NXPlotTab(QtWidgets.QWidget):
         num = self.plotcombo.currentText()
         self.plotview.num = int(num)
         self.smoothing = self.plotview.plots[num]['smoothing']    
-
-    def spinbox(self, slot):
-        """Return a NXSpinBox with a signal slot."""
-        spinbox = NXSpinBox()
-        spinbox.setAlignment(QtCore.Qt.AlignRight)
-        spinbox.setFixedWidth(100)
-        spinbox.setKeyboardTracking(False)
-        spinbox.setAccelerated(False)
-        spinbox.valueChanged[six.text_type].connect(slot)
-        return spinbox
-
-    def doublespinbox(self, slot):
-        """Return a NXDoubleSpinBox with a signal slot."""
-        doublespinbox = NXDoubleSpinBox()
-        doublespinbox.setAlignment(QtCore.Qt.AlignRight)
-        doublespinbox.setFixedWidth(100)
-        doublespinbox.setKeyboardTracking(False)
-        doublespinbox.valueChanged[six.text_type].connect(slot)
-        return doublespinbox
-
-    def slider(self, slot):
-        """Return a QSlider with a signal slot."""
-        slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
-        slider.setFocusPolicy(QtCore.Qt.NoFocus)
-        slider.setMinimumWidth(100)
-        slider.setRange(0, 1000)
-        slider.setSingleStep(5)
-        slider.setValue(0)
-        slider.setTracking(True)
-        slider.sliderReleased.connect(slot)
-        if self.name != 'v':
-            slider.sliderMoved.connect(slot)
-        return slider
 
     @QtCore.Slot()
     def read_maxbox(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -724,6 +724,7 @@ class NXPlotView(QtWidgets.QDialog):
 
         if over:
             self.update_tabs()
+            self.update_panels()
         else:
             self.init_tabs()
 
@@ -1055,6 +1056,8 @@ class NXPlotView(QtWidgets.QDialog):
         p['linestyle'] = p['plot'].get_linestyle()
         p['linewidth'] = p['plot'].get_linewidth()
         p['zorder'] = p['plot'].get_zorder()
+        p['scale'] = 1.0
+        p['offset'] = 0.0
         try:
             p['smooth_function'] = interp1d(self.x, self.y, kind='cubic')
         except Exception as error:

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -394,7 +394,7 @@ class NXTreeView(QtWidgets.QTreeView):
             except Exception as error:
                 pass
         try:
-            if node.is_numeric():
+            if node.is_plottable() or node.is_numeric():
                 self.mainwindow.plot_data_action.setEnabled(True)
                 if ((isinstance(node, NXgroup) and
                     node.nxsignal is not None and 

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -394,7 +394,7 @@ class NXTreeView(QtWidgets.QTreeView):
             except Exception as error:
                 pass
         try:
-            if node.is_plottable():
+            if node.is_numeric():
                 self.mainwindow.plot_data_action.setEnabled(True)
                 if ((isinstance(node, NXgroup) and
                     node.nxsignal is not None and 

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -433,7 +433,9 @@ class NXSpinBox(QtWidgets.QSpinBox):
 
     Parameters
     ----------
-    data : array-like
+    slot : function
+        PyQt slot triggered by changing values  
+    data : array-like, optional
         Values of data to be adjusted by the spin box.
 
     Attributes
@@ -450,20 +452,20 @@ class NXSpinBox(QtWidgets.QSpinBox):
     pause : bool
         Used when playing a movie with changing z-values.
     """
-    def __init__(self, data=None):
-        """Initialize the spin box
-        
-        Parameters
-        ----------
-        data : array-like, optional
-            The data to be set by the spin box.   
-        """
+    def __init__(self, slot=None, data=None):
         super(NXSpinBox, self).__init__()
         self.data = data
         self.validator = QtGui.QDoubleValidator()
         self.old_value = None
         self.diff = None
         self.pause = False
+        if slot:
+            self.valueChanged[six.text_type].connect(slot)
+
+        self.setAlignment(QtCore.Qt.AlignRight)
+        self.setFixedWidth(100)
+        self.setKeyboardTracking(False)
+        self.setAccelerated(False)
 
     def value(self):
         """Return the value of the spin box.
@@ -579,14 +581,36 @@ class NXSpinBox(QtWidgets.QSpinBox):
 
 
 class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
+    """Subclass of QDoubleSpinBox.
 
-    def __init__(self, data=None):
+    Parameters
+    ----------
+    slot : function
+        PyQt slot triggered by changing values  
+
+    Attributes
+    ----------
+    validator : QDoubleValidator
+        Function to ensure only floating point values are entered.
+    old_value : float
+        Previously stored value.
+    diff : float
+        Difference between maximum and minimum values when the box is
+        locked.
+    """
+    def __init__(self, slot=None):
         super(NXDoubleSpinBox, self).__init__()
         self.validator = QtGui.QDoubleValidator()
         self.validator.setRange(-np.inf, np.inf)
         self.validator.setDecimals(1000)
         self.old_value = None
         self.diff = None
+        if slot:
+            self.valueChanged[six.text_type].connect(slot)    
+
+        self.setAlignment(QtCore.Qt.AlignRight)
+        self.setFixedWidth(100)
+        self.setKeyboardTracking(False)
 
     def validate(self, input_value, position):
         return self.validator.validate(input_value, position)
@@ -615,6 +639,31 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         elif value < self.minimum():
             self.setMinimum(value)
         super(NXDoubleSpinBox, self).setValue(value)
+
+
+class NXSlider(QtWidgets.QSlider):
+    """Subclass of QSlider.
+
+    Parameters
+    ----------
+    slot : function
+        PyQt slot triggered by changing values
+    move : bool
+        True if the slot is triggered by moving the slider. Otherwise, 
+        it is only triggered on release.
+    """
+    def __init__(self, slot=None, move=True):
+        super(NXSlider, self).__init__(QtCore.Qt.Horizontal)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setMinimumWidth(100)
+        self.setRange(0, 1000)
+        self.setSingleStep(5)
+        self.setValue(0)
+        self.setTracking(True)
+        if slot:
+            self.sliderReleased.connect(slot)
+            if move:    
+                self.sliderMoved.connect(slot)
 
 
 class NXpatch(object):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -247,7 +247,7 @@ class NXCheckBox(QtWidgets.QCheckBox):
         Parameters
         ----------
         label : str, optional
-            Text describing the checkbox
+            Text describing the checkbox.
         slot : func, optional
             Function to be called when the checkbox state is changed.
         checked : bool, optional


### PR DESCRIPTION
* Add scale and offset fields to the Customize Panel to allow 1D data to be adjusted in a plot.
* Create a new dialog to allow scalar fields to be plotted across multiple files. It is similar to the Scan Panel, but is initiated using the "Plot Data" dialog.
* Include 1D scans in the Scan Panel.
* Allow the typing of prefixes to select files in the "Open Directory" dialog and Scan Panels.
* Fix appearance of the overplot box when copying limits in the Projection Panel.