### PR TITLE
Catch backup file delete exceptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ h5py
 nexusformat
 numpy
 scipy
-pyqt5
+pyqt5<=5.13
 qtconsole
 matplotlib
 ansi2html

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -203,8 +203,11 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
                     os.path.realpath(backup).startswith(self.backup_dir)):
                 self.settings.remove_option('backups', backup)
             elif backup_age(backup) > 5:
-                shutil.rmtree(os.path.dirname(os.path.realpath(backup)))
-                self.settings.remove_option('backups', backup)
+                try:
+                    shutil.rmtree(os.path.dirname(os.path.realpath(backup)))
+                    self.settings.remove_option('backups', backup)
+                except OSError:
+                    pass
         self.settings.save()
 
     def init_log(self):


### PR DESCRIPTION
* Prevent startup failure if purging backup files fails due to a file that cannot be deleted.