### PR TITLE
Improve panel behavior

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ h5py
 nexusformat
 numpy
 scipy
-pyqt5
+pyqt5<=5.13
 qtconsole
 matplotlib
 ansi2html

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -63,6 +63,7 @@ class NXWidget(QtWidgets.QWidget):
         self.tree = self.treeview.tree
         self.plotview = self.mainwindow.plotview
         self.plotviews = self.mainwindow.plotviews
+        self.active_plotview = self.mainwindow.active_plotview
         self.default_directory = self.mainwindow.default_directory
         self.import_file = None     # must define in subclass
         self.nexus_filter = ';;'.join((
@@ -1692,6 +1693,7 @@ class CustomizeTab(NXTab):
         from .plotview import markers, linestyles
         self.markers, self.linestyles = markers, linestyles
 
+        self.plotview = self.active_plotview
         self.name = self.plotview.label
 
         self.parameters = {}
@@ -1982,6 +1984,7 @@ class ProjectionTab(NXTab):
             self.tabs = parent.tabs
             self.labels = parent.labels
 
+        self.plotview = self.active_plotview
         self.name = self.plotview.label
         self.ndim = self.plotview.ndim
 
@@ -2270,7 +2273,8 @@ class ProjectionTab(NXTab):
     @property
     def rectangle(self):
         if self._rectangle not in self.plotview.ax.patches:
-            self._rectangle = NXpolygon(self.get_rectangle(), closed=True).shape
+            self._rectangle = NXpolygon(self.get_rectangle(), closed=True,
+                                        plotview=self.plotview).shape
             self._rectangle.set_edgecolor(self.plotview._gridcolor)
             self._rectangle.set_facecolor('none')
             self._rectangle.set_linestyle('dashed')
@@ -2404,6 +2408,7 @@ class LimitTab(NXTab):
             self.tabs = parent.tabs
             self.labels = parent.labels
 
+        self.plotview = self.active_plotview
         self.name = self.plotview.label
         self.ndim = self.plotview.ndim
         
@@ -3139,7 +3144,8 @@ class ScanTab(NXTab):
     @property
     def rectangle(self):
         if self._rectangle not in self.plotview.ax.patches:
-            self._rectangle = NXpolygon(self.get_rectangle(), closed=True).shape
+            self._rectangle = NXpolygon(self.get_rectangle(), closed=True,
+                                        plotview=self.plotview).shape
             self._rectangle.set_edgecolor(self.plotview._gridcolor)
             self._rectangle.set_facecolor('none')
             self._rectangle.set_linestyle('dotted')

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -706,6 +706,7 @@ class NXPanel(NXDialog):
     def remove(self, label):
         if label in self.tabs:
             try:
+                self.tabs[label].close()
                 self.tabwidget.removeTab(self.tabwidget.indexOf(self.tabs[label]))
             except Exception:
                 pass

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -200,6 +200,11 @@ class MainWindow(QtWidgets.QMainWindow):
         from .plotview import plotview
         return plotview
         
+    @property
+    def active_plotview(self):
+        from .plotview import active_plotview
+        return active_plotview
+        
     # Populate the menu bar with common actions and shortcuts
     def add_menu_action(self, menu, action, defer_shortcut=False):
         """Add action to menu as well as self

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -517,7 +517,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.overplot_data_action=QtWidgets.QAction("Overplot Data",
             self,
-            shortcut=QtGui.QKeySequence("Ctrl+Alt+P"),
+            shortcut=QtGui.QKeySequence("Ctrl+Shift+P"),
             triggered=self.overplot_data
             )
         self.add_menu_action(self.data_menu, self.overplot_data_action)

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -262,7 +262,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.openimage_action=QtWidgets.QAction("Open Image...",
             self,
-            shortcut="Ctrl+Alt+O",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+O"),
             triggered=self.open_image
             )
         self.add_menu_action(self.file_menu, self.openimage_action)
@@ -500,7 +500,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.plot_data_action=QtWidgets.QAction("&Plot Data",
             self,
-            shortcut="Ctrl+P",
+            shortcut=QtGui.QKeySequence("Ctrl+P"),
             triggered=self.plot_data
             )
         self.add_menu_action(self.data_menu, self.plot_data_action)
@@ -512,7 +512,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.overplot_data_action=QtWidgets.QAction("Overplot Data",
             self,
-            shortcut="Ctrl+Alt+P",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+P"),
             triggered=self.overplot_data
             )
         self.add_menu_action(self.data_menu, self.overplot_data_action)
@@ -544,7 +544,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.view_action=QtWidgets.QAction("View Data",
             self,
-            shortcut="Ctrl+Alt+V",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+V"),
             triggered=self.view_data
             )
         self.add_menu_action(self.data_menu, self.view_action)
@@ -669,7 +669,7 @@ class MainWindow(QtWidgets.QMainWindow):
             # disable on OSX, where there is always a menu bar
             self.toggle_menu_bar_act = QtWidgets.QAction("Toggle &Menu Bar",
                 self,
-                shortcut="Ctrl+Shift+M",
+                shortcut=QtGui.QKeySequence("Ctrl+Shift+M"),
                 statusTip="Toggle visibility of menubar",
                 triggered=self.toggle_menu_bar)
             self.add_menu_action(self.view_menu, self.toggle_menu_bar_act)
@@ -700,7 +700,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.reset_font_size = QtWidgets.QAction("Zoom &Reset",
             self,
-            shortcut="Ctrl+0",
+            shortcut=QtGui.QKeySequence("Ctrl+0"),
             triggered=self.reset_font_size_console
             )
         self.add_menu_action(self.view_menu, self.reset_font_size, True)
@@ -773,13 +773,13 @@ class MainWindow(QtWidgets.QMainWindow):
             # add min/maximize actions to OSX, which lacks default bindings.
             self.minimizeAct = QtWidgets.QAction("Mini&mize",
                 self,
-                shortcut="Ctrl+m",
+                shortcut=QtGui.QKeySequence("Ctrl+m"),
                 statusTip="Minimize the window/Restore Normal Size",
                 triggered=self.toggleMinimized)
             # maximize is called 'Zoom' on OSX for some reason
             self.maximizeAct = QtWidgets.QAction("&Zoom",
                 self,
-                shortcut="Ctrl+Shift+M",
+                shortcut=QtGui.QKeySequence("Ctrl+Shift+M"),
                 statusTip="Maximize the window/Restore Normal Size",
                 triggered=self.toggleMaximized)
 
@@ -821,15 +821,15 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.customize_action=QtWidgets.QAction("Show Customize Panel",
             self,
-            shortcut="Ctrl+Alt+C",
-            triggered=self.customize_plot
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+C"),
+            triggered=self.show_customize_panel
             )
         self.add_menu_action(self.window_menu, self.customize_action)
 
         self.limit_action=QtWidgets.QAction("Show Limits Panel",
             self,
-            shortcut="Ctrl+Alt+L",
-            triggered=self.limit_axes
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+L"),
+            triggered=self.show_limits_panel
             )
         self.add_menu_action(self.window_menu, self.limit_action)
 
@@ -842,7 +842,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.scan_action=QtWidgets.QAction("Show Scan Panel",
             self,
-            shortcut="Ctrl+Alt+S",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+S"),
             triggered=self.show_scan_panel
             )
         self.add_menu_action(self.window_menu, self.scan_action)
@@ -851,14 +851,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.reset_limit_action=QtWidgets.QAction("Reset Plot Limits",
             self,
-            shortcut="Ctrl+Alt+Shift+L",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+Shift+L"),
             triggered=self.reset_axes
             )
         self.add_menu_action(self.window_menu, self.reset_limit_action)
 
         self.preferences_action=QtWidgets.QAction("Edit Preferences",
             self,
-            shortcut="Ctrl+Alt+E",
+            shortcut=QtGui.QKeySequence("Ctrl+Alt+E"),
             triggered=self.edit_preferences
             )
 #        self.add_menu_action(self.window_menu, self.preferences_action)
@@ -2074,27 +2074,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.update_active(number)
             self.plotviews[self.active_action[number].text()].make_active()
 
-    def limit_axes(self):
-        try:
-            if 'limit' not in self.panels:
-                self.panels['limit'] = LimitDialog(parent=self)
-            self.panels['limit'].activate(self.plotview.label)
-        except NeXusError as error:
-            report_error("Changing Plot Limits", error)
-
     def reset_axes(self):
         try:
             self.plotview.reset_plot_limits()
         except NeXusError as error:
             report_error("Resetting Plot Limits", error)
-
-    def customize_plot(self):
-        try:
-            if 'customize' not in self.panels:
-                self.panels['customize'] = CustomizeDialog(parent=self)
-            self.panels['customize'].activate(self.plotview.label)
-        except NeXusError as error:
-            report_error("Customizing Plot", error)
 
     def edit_preferences(self):
         try:
@@ -2123,6 +2107,22 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.log_window = LogDialog(parent=self)
         except NeXusError as error:
             report_error("Showing Log File", error)
+
+    def show_customize_panel(self):
+        try:
+            if 'customize' not in self.panels:
+                self.panels['customize'] = CustomizeDialog(parent=self)
+            self.panels['customize'].activate(self.plotview.label)
+        except NeXusError as error:
+            report_error("Showing Customize Panel", error)
+
+    def show_limits_panel(self):
+        try:
+            if 'limit' not in self.panels:
+                self.panels['limit'] = LimitDialog(parent=self)
+            self.panels['limit'].activate(self.plotview.label)
+        except NeXusError as error:
+            report_error("Showing Limits Panel", error)
 
     def show_projection_panel(self):
         if self.plotview.label == 'Projection' or self.plotview.ndim == 1:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2117,7 +2117,7 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             if 'customize' not in self.panels:
                 self.panels['customize'] = CustomizeDialog(parent=self)
-            self.panels['customize'].activate(self.plotview.label)
+            self.panels['customize'].activate(self.active_plotview.label)
         except NeXusError as error:
             report_error("Showing Customize Panel", error)
 
@@ -2125,7 +2125,7 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             if 'limit' not in self.panels:
                 self.panels['limit'] = LimitDialog(parent=self)
-            self.panels['limit'].activate(self.plotview.label)
+            self.panels['limit'].activate(self.active_plotview.label)
         except NeXusError as error:
             report_error("Showing Limits Panel", error)
 
@@ -2135,7 +2135,7 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             if 'projection' not in self.panels:
                 self.panels['projection'] = ProjectionDialog(parent=self)
-            self.panels['projection'].activate(self.plotview.label)
+            self.panels['projection'].activate(self.active_plotview.label)
         except NeXusError as error:
             report_error("Showing Projection Panel", error)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -69,6 +69,7 @@ from .widgets import (NXSpinBox, NXDoubleSpinBox, NXSlider, NXComboBox,
 from .utils import (report_error, report_exception, boundaries, centers, keep_data, 
                     fix_projection, find_nearest, iterable)
 
+active_plotview = None
 plotview = None
 plotviews = {}
 colors = mpl.rcParams['axes.prop_cycle'].by_key()['color']
@@ -563,7 +564,8 @@ class NXPlotView(QtWidgets.QDialog):
 
     def make_active(self):
         """Make this window active for plotting."""
-        global plotview
+        global active_plotview, plotview
+        active_plotview = self
         if self.number < 101:
             plotview = self
             self.mainwindow.user_ns['plotview'] = self

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2230,7 +2230,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.vtab.set_axis(self.vaxis)
             if self.tab_widget.indexOf(self.vtab) == -1:
                 self.tab_widget.insertTab(0, self.vtab, 'signal')
-            if self.number < 100:
+            if self.label != 'Projection':
                 if self.tab_widget.indexOf(self.ptab) == -1:
                     self.tab_widget.insertTab(
                         self.tab_widget.indexOf(self.otab),

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1246,7 +1246,6 @@ class NXPlotView(QtWidgets.QDialog):
         ax.set_xlabel(self.xaxis.label)
         ax.set_ylabel(self.yaxis.label)
         self.otab.push_current()
-        self.update_panels()
         if self.ndim == 1:
             try:
                 self.plot_smooth()


### PR DESCRIPTION
* Allow the Limits and Projection Panels to be invoked from a Scan Panel plot.
* Allow the Customize Panel to be invoked from a Projection Panel plot.
* Fix bug causing reset of values in the Limits Panel when clicking "Apply".
* Ensure that the copy pulldown menus are updated when closing tabs.
* Change the "Overplot" keyboard shortcut to Ctrl+Shift+P because of duplication with the "Show Projection Panel" shortcut, Ctrl+Alt+P.