### PR TITLE
Add dependency on qtpy module

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexpy
-  version: "0.12.2"
+  version: "0.12.4"
 
 source:
   git_url: https://github.com/nexpy/nexpy.git
-  git_tag: v0.12.2
+  git_tag: v0.12.4
 
 build:
   entry_points:
@@ -19,6 +19,7 @@ requirements:
     - numpy
     - scipy
     - h5py
+    - qtpy
     - qtconsole
     - matplotlib
     - six
@@ -30,6 +31,7 @@ requirements:
     - numpy
     - scipy
     - h5py
+    - qtpy
     - qtconsole
     - matplotlib
     - ansi2html

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ h5py
 nexusformat
 numpy
 scipy
+qtpy
 pyqt5<=5.13
 qtconsole
 matplotlib

--- a/src/nexpy/requires.py
+++ b/src/nexpy/requires.py
@@ -15,6 +15,7 @@ pkg_requirements = [
     'numpy',
     'scipy',
     'h5py',
+    'qtpy',
     'qtconsole',
     'ipython',
     'matplotlib',


### PR DESCRIPTION
* This follows the merge of a PR to switch to the `qtpy` module for handling PyQt imports.