### PR TITLE
Improve sliders

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1407,12 +1407,12 @@ class NXPlotView(QtWidgets.QDialog):
     def reset_plot_limits(self, autoscale=True):
         """Restore the plot limits to the original values."""
         xmin, xmax, ymin, ymax = self.limits
-        self.xaxis.min = self.xaxis.lo = self.xtab.minbox.old_value = xmin
-        self.xaxis.max = self.xaxis.hi = self.xtab.maxbox.old_value = xmax
+        self.xaxis.min = self.xaxis.lo = xmin
+        self.xaxis.max = self.xaxis.hi = xmax
         if self.logx:
             self.xaxis.lo, self.xaxis.hi = self.xaxis.log_limits()
-        self.yaxis.min = self.yaxis.lo = self.ytab.minbox.old_value = ymin
-        self.yaxis.max = self.yaxis.hi = self.ytab.maxbox.old_value = ymax
+        self.yaxis.min = self.yaxis.lo = ymin
+        self.yaxis.max = self.yaxis.hi = ymax
         if self.logy:
             self.yaxis.lo, self.yaxis.hi = self.yaxis.log_limits()
         if self.ndim == 1:
@@ -2684,8 +2684,6 @@ class NXPlotTab(QtWidgets.QWidget):
         else:
             self.set_range()
             self.set_limits(axis.lo, axis.hi)
-        self.minbox.old_value = axis.lo
-        self.maxbox.old_value = axis.hi
         if not self.zaxis:
             self.axis.locked = False
             if np.all(self.axis.data[np.isfinite(self.axis.data)] <= 0.0):
@@ -2755,17 +2753,14 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.axis.lo = self.axis.hi - self.axis.diff
                 if not np.isclose(self.axis.lo, self.minbox.old_value):
                     self.minbox.setValue(self.axis.lo)
-                    self.minbox.old_value = self.axis.lo
                 self.replotSignal.replot.emit()
             else:
                 self.axis.hi = hi
                 if self.axis.hi < self.axis.lo:
                     self.axis.lo = self.axis.hi
                     self.minbox.setValue(self.axis.lo)
-                    self.minbox.old_value = self.axis.lo
                 elif np.isclose(self.axis.lo, self.axis.hi):
                     self.replotSignal.replot.emit()
-        self.maxbox.old_value = self.axis.hi
 
     @QtCore.Slot()
     def read_minbox(self):
@@ -2794,8 +2789,6 @@ class NXPlotTab(QtWidgets.QWidget):
             if lo > self.axis.hi:
                 self.axis.hi = self.axis.lo
                 self.maxbox.setValue(self.axis.hi)
-                self.maxbox.old_value = self.axis.hi
-        self.minbox.old_value = self.axis.lo
 
     def read_maxslider(self):
         self.block_signals(True)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2721,6 +2721,7 @@ class NXPlotTab(QtWidgets.QWidget):
 
     def edit_maxbox(self):
         self.axis.hi = self.axis.max = self.maxbox.value()
+        self.maxbox.old_value = self.axis.hi
         if self.axis.hi < self.axis.lo:
             self.axis.lo = self.axis.data.min()
             self.minbox.setValue(self.axis.lo)
@@ -2761,6 +2762,7 @@ class NXPlotTab(QtWidgets.QWidget):
 
     def edit_minbox(self):
         self.axis.lo = self.axis.min = self.minbox.value()
+        self.minbox.old_value = self.axis.lo
         if self.axis.lo > self.axis.hi:
             self.axis.hi = self.axis.max = self.axis.data.max()
             self.maxbox.setValue(self.axis.hi)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2719,7 +2719,6 @@ class NXPlotTab(QtWidgets.QWidget):
         self.plotview.num = int(num)
         self.smoothing = self.plotview.plots[num]['smoothing']    
 
-    @QtCore.Slot()
     def read_maxbox(self):
         """Update plot based on the maxbox value."""
         hi = self.maxbox.value()
@@ -2762,7 +2761,6 @@ class NXPlotTab(QtWidgets.QWidget):
                 elif np.isclose(self.axis.lo, self.axis.hi):
                     self.replotSignal.replot.emit()
 
-    @QtCore.Slot()
     def read_minbox(self):
         lo = self.minbox.value()
         if not self.minbox.isEnabled() or self.axis.locked or \

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1210,6 +1210,7 @@ class NXPlotView(QtWidgets.QDialog):
             if self.colorbar:
                 self.colorbar.locator = self.locator
                 self.colorbar.formatter = self.formatter
+                self.colorbar.minorticks_off()
                 self.update_colorbar()
             self.image.set_clim(self.vaxis.lo, self.vaxis.hi)
             if self.regular_grid:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2729,6 +2729,7 @@ class NXPlotTab(QtWidgets.QWidget):
         self.set_range()
         self.block_signals(False)
         self.set_sliders(self.axis.lo, self.axis.hi)
+        self.set_stepsize(self.axis.lo, self.axis.hi)
 
     def read_maxbox(self):
         """Update plot based on the maxbox value."""
@@ -2745,6 +2746,7 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.plotview.replot_image()
             else:
                 self.plotview.replot_axes()
+            self.set_stepsize(self.axis.lo, self.axis.hi)
         else:
             if self.axis.locked:
                 self.axis.hi = hi
@@ -2770,6 +2772,7 @@ class NXPlotTab(QtWidgets.QWidget):
         self.set_range()
         self.block_signals(False)
         self.set_sliders(self.axis.lo, self.axis.hi)
+        self.set_stepsize(self.axis.lo, self.axis.hi)
 
     def read_minbox(self):
         self.block_signals(True)
@@ -2782,6 +2785,7 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.plotview.replot_image()
             else:
                 self.plotview.replot_axes()
+            self.set_stepsize(self.axis.lo, self.axis.hi)
         else:
             self.axis.lo = lo
             if lo > self.axis.hi:
@@ -2812,6 +2816,7 @@ class NXPlotTab(QtWidgets.QWidget):
                                         (self.axis.lo - self.axis.min) / _range)
             except (ZeroDivisionError, OverflowError, RuntimeWarning):
                 self.minslider.setValue(0)
+        self.set_stepsize(self.axis.lo, self.axis.hi)
         if self.name == 'x' or self.name == 'y':
             self.plotview.replot_axes()
         else:
@@ -2832,6 +2837,7 @@ class NXPlotTab(QtWidgets.QWidget):
                                     (self.axis.hi-self.axis.lo)/_range)
         except (ZeroDivisionError, OverflowError, RuntimeWarning):
             self.maxslider.setValue(0)
+        self.set_stepsize(self.axis.lo, self.axis.hi)
         if self.name == 'x' or self.name == 'y':
             self.plotview.replot_axes()
         else:
@@ -2937,17 +2943,20 @@ class NXPlotTab(QtWidgets.QWidget):
 
     @QtCore.Slot()
     def reset(self):
-        self.set_range()
         self.set_limits(self.axis.min, self.axis.max)
 
     def set_range(self):
         """Set the range and step sizes for the minbox and maxbox."""
-        if np.isclose(self.axis.min, self.axis.max):
+        if np.isclose(self.axis.lo, self.axis.hi):
             self.axis.min, self.axis.max = nonsingular(self.axis.min, 
                                                        self.axis.max)
         self.minbox.setRange(self.axis.min, self.axis.max)
         self.maxbox.setRange(self.axis.min, self.axis.max)
-        range = self.axis.max - self.axis.min
+        self.set_stepsize(self.axis.min, self.axis.max)
+
+    def set_stepsize(self, lo, hi):
+        """Set the step sizes based on the current minbox and maxbox values."""
+        range = hi - lo
         self.minbox.setSingleStep((range)/100)
         self.maxbox.setSingleStep((range)/100)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1674,6 +1674,27 @@ class NXPlotView(QtWidgets.QDialog):
     offsets = property(_offsets, _set_offsets, 
                        "Property: Axis offsets property")
 
+    def minorticks_on(self):
+        """Turn on minor ticks on the axes."""
+        self.ax.minorticks_on()
+        self.draw()
+
+    def minorticks_off(self):
+        """Turn off minor ticks on the axes."""
+        self.ax.minorticks_off()
+        self.draw()
+
+    def cb_minorticks_on(self):
+        """Turn on minor ticks on the colorbar."""
+        if self.colorbar:
+            self.colorbar.minorticks_on()
+            self.draw()
+
+    def cb_minorticks_off(self):
+        """Turn off minor ticks on the axes."""
+        self.colorbar.minorticks_off()
+        self.draw()
+
     @property
     def regular_grid(self):
         """Return whether it is possible to use 'imshow'.

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2861,6 +2861,42 @@ class NXPlotTab(QtWidgets.QWidget):
             self.maxslider.setValue(0)
         self.block_signals(False)
 
+    def set_range(self):
+        """Set the range and step sizes for the minbox and maxbox."""
+        if np.isclose(self.axis.lo, self.axis.hi):
+            self.axis.min, self.axis.max = nonsingular(self.axis.min, 
+                                                       self.axis.max)
+        self.minbox.setRange(self.axis.min, self.axis.max)
+        self.maxbox.setRange(self.axis.min, self.axis.max)
+        self.set_stepsize(self.axis.min, self.axis.max)
+
+    def set_stepsize(self, lo, hi):
+        """Set the step sizes based on the current minbox and maxbox values."""
+        range = hi - lo
+        self.minbox.setSingleStep((range)/100)
+        self.maxbox.setSingleStep((range)/100)
+
+    def get_limits(self):
+        """Return the minbox and maxbox values."""
+        return self.minbox.value(), self.maxbox.value()
+
+    def set_limits(self, lo, hi):
+        """Set the minbox and maxbox limits and sliders."""
+        self.block_signals(True)
+        if lo > hi:
+            lo, hi = hi, lo
+        self.axis.set_limits(lo, hi)
+        self.minbox.setValue(lo)
+        self.maxbox.setValue(hi)
+        if not self.zaxis:
+            self.set_sliders(lo, hi)
+            self.set_stepsize(lo, hi)
+        self.block_signals(False)
+
+    @QtCore.Slot()
+    def reset(self):
+        self.set_limits(self.axis.min, self.axis.max)
+
     def block_signals(self, block=True):
         self.minbox.blockSignals(block)
         self.maxbox.blockSignals(block)
@@ -2940,41 +2976,6 @@ class NXPlotTab(QtWidgets.QWidget):
             self.plotview.replot_axes()
         except:
             pass
-
-    @QtCore.Slot()
-    def reset(self):
-        self.set_limits(self.axis.min, self.axis.max)
-
-    def set_range(self):
-        """Set the range and step sizes for the minbox and maxbox."""
-        if np.isclose(self.axis.lo, self.axis.hi):
-            self.axis.min, self.axis.max = nonsingular(self.axis.min, 
-                                                       self.axis.max)
-        self.minbox.setRange(self.axis.min, self.axis.max)
-        self.maxbox.setRange(self.axis.min, self.axis.max)
-        self.set_stepsize(self.axis.min, self.axis.max)
-
-    def set_stepsize(self, lo, hi):
-        """Set the step sizes based on the current minbox and maxbox values."""
-        range = hi - lo
-        self.minbox.setSingleStep((range)/100)
-        self.maxbox.setSingleStep((range)/100)
-
-    def get_limits(self):
-        """Return the minbox and maxbox values."""
-        return self.minbox.value(), self.maxbox.value()
-
-    def set_limits(self, lo, hi):
-        """Set the minbox and maxbox limits and sliders."""
-        self.block_signals(True)
-        if lo > hi:
-            lo, hi = hi, lo
-        self.axis.set_limits(lo, hi)
-        self.minbox.setValue(lo)
-        self.maxbox.setValue(hi)
-        if not self.zaxis:
-            self.set_sliders(lo, hi)
-        self.block_signals(False)
 
     def change_axis(self):
         """Change the axis for the current tab."""

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2606,6 +2606,7 @@ class NXPlotTab(QtWidgets.QWidget):
             else:
                 self.minslider = NXSlider(self.read_minslider)
                 self.maxslider = NXSlider(self.read_maxslider)
+            self.slider_max = self.maxslider.maximum()
             self.maxbox = NXDoubleSpinBox(self.read_maxbox)
             if log:
                 self.logbox = NXCheckBox("Log", self.change_log)
@@ -2800,22 +2801,23 @@ class NXPlotTab(QtWidgets.QWidget):
         self.block_signals(True)
         if self.name == 'v' and self.symmetric:
             _range = max(self.axis.max, self.axis.min_range)
-            self.axis.hi = max((self.maxslider.value()*_range/1000), 
+            self.axis.hi = max((self.maxslider.value()*_range/self.slider_max), 
                                 self.axis.min_range)
             self.axis.lo = -self.axis.hi
             self.maxbox.setValue(self.axis.hi)
             self.minbox.setValue(self.axis.lo)
-            self.minslider.setValue(1000 - self.maxslider.value())
+            self.minslider.setValue(self.slider_max - self.maxslider.value())
         else:
             self.axis.lo = self.minbox.value()
             _range = max(self.axis.max - self.axis.lo, self.axis.min_range)
             self.axis.hi = self.axis.lo + max(
-                (self.maxslider.value()*_range/1000), self.axis.min_range)
+                (self.maxslider.value() * _range / self.slider_max), 
+                 self.axis.min_range)
             self.maxbox.setValue(self.axis.hi)
             _range = max(self.axis.hi - self.axis.min, self.axis.min_range)
             try:
-                self.minslider.setValue(1000*(self.axis.lo - self.axis.min) / 
-                                        _range)
+                self.minslider.setValue(self.slider_max *
+                                        (self.axis.lo - self.axis.min) / _range)
             except (ZeroDivisionError, OverflowError, RuntimeWarning):
                 self.minslider.setValue(1000)
         if self.name == 'x' or self.name == 'y':
@@ -2829,11 +2831,13 @@ class NXPlotTab(QtWidgets.QWidget):
         self.block_signals(True)
         self.axis.hi = self.maxbox.value()
         _range = max(self.axis.hi - self.axis.min, self.axis.min_range)
-        self.axis.lo = self.axis.min + (self.minslider.value()*_range/1000)
+        self.axis.lo = self.axis.min + (self.minslider.value()*_range / 
+                                        self.slider_max)
         self.minbox.setValue(self.axis.lo)
         _range = max(self.axis.max-self.axis.lo, self.axis.min_range)
         try:
-            self.maxslider.setValue(1000*(self.axis.hi-self.axis.lo)/_range)
+            self.maxslider.setValue(self.slider_max * 
+                                    (self.axis.hi-self.axis.lo)/_range)
         except (ZeroDivisionError, OverflowError, RuntimeWarning):
             self.maxslider.setValue(0)
         if self.name == 'x' or self.name == 'y':
@@ -2848,12 +2852,13 @@ class NXPlotTab(QtWidgets.QWidget):
         self.block_signals(True)
         _range = max(hi-self.axis.min, self.axis.min_range)
         try:
-            self.minslider.setValue(1000*(lo - self.axis.min)/_range)
+            self.minslider.setValue(self.slider_max * 
+                                    (lo - self.axis.min) / _range)
         except (ZeroDivisionError, OverflowError, RuntimeWarning):
-            self.minslider.setValue(1000)
+            self.minslider.setValue(self.slider_max)
         _range = max(self.axis.max - lo, self.axis.min_range)
         try:
-            self.maxslider.setValue(1000*(hi-lo)/_range)
+            self.maxslider.setValue(self.slider_max * (hi-lo) / _range)
         except (ZeroDivisionError, OverflowError, RuntimeWarning):
             self.maxslider.setValue(0)
         self.block_signals(False)
@@ -3051,7 +3056,7 @@ class NXPlotTab(QtWidgets.QWidget):
         self.minbox.setMaximum(0.0)
         self.minbox.setValue(-self.maxbox.value())
         self.minbox.setDisabled(True)
-        self.minslider.setValue(1000-self.maxslider.value())
+        self.minslider.setValue(self.slider_max - self.maxslider.value())
         self.minslider.setDisabled(True)
 
     def change_interpolation(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2601,7 +2601,8 @@ class NXPlotTab(QtWidgets.QWidget):
             self.plotcombo.setMinimumWidth(20)
             self.minbox = NXDoubleSpinBox(self.read_minbox)
             if self.name == 'v':
-                self.minslider = NXSlider(self.read_minslider, move=False)
+                self.minslider = NXSlider(self.read_minslider, move=False,
+                                          inverse=True)
                 self.maxslider = NXSlider(self.read_maxslider, move=False)
             else:
                 self.minslider = NXSlider(self.read_minslider, inverse=True)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2604,7 +2604,7 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.minslider = NXSlider(self.read_minslider, move=False)
                 self.maxslider = NXSlider(self.read_maxslider, move=False)
             else:
-                self.minslider = NXSlider(self.read_minslider)
+                self.minslider = NXSlider(self.read_minslider, inverse=True)
                 self.maxslider = NXSlider(self.read_maxslider)
             self.slider_max = self.maxslider.maximum()
             self.maxbox = NXDoubleSpinBox(self.read_maxbox)
@@ -2819,7 +2819,7 @@ class NXPlotTab(QtWidgets.QWidget):
                 self.minslider.setValue(self.slider_max *
                                         (self.axis.lo - self.axis.min) / _range)
             except (ZeroDivisionError, OverflowError, RuntimeWarning):
-                self.minslider.setValue(1000)
+                self.minslider.setValue(0)
         if self.name == 'x' or self.name == 'y':
             self.plotview.replot_axes()
         else:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1025,11 +1025,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.colorbar = self.figure.colorbar(self.image, ax=ax)
             self.colorbar.locator = self.locator
             self.colorbar.formatter = self.formatter
-            if mpl.__version__ >= '3.1.0':
-                self.colorbar.update_normal(self.image)
-            else:
-                self.colorbar.set_norm(self.norm)
-                self.colorbar.update_bruteforce(self.image)
+            self.update_colorbar()
 
         xlo, ylo = self.transform(self.xaxis.lo, self.yaxis.lo)
         xhi, yhi = self.transform(self.xaxis.hi, self.yaxis.hi)
@@ -1214,11 +1210,7 @@ class NXPlotView(QtWidgets.QDialog):
             if self.colorbar:
                 self.colorbar.locator = self.locator
                 self.colorbar.formatter = self.formatter
-                if mpl.__version__ >= '3.1.0':
-                    self.colorbar.update_normal(self.image)
-                else:
-                    self.colorbar.set_norm(self.norm)
-                    self.colorbar.update_bruteforce(self.image)
+                self.update_colorbar()
             self.image.set_clim(self.vaxis.lo, self.vaxis.hi)
             if self.regular_grid:
                 if self.interpolation == 'convolve':
@@ -1257,6 +1249,13 @@ class NXPlotView(QtWidgets.QDialog):
         if draw:
             self.draw()
         self.update_panels()
+
+    def update_colorbar(self):
+        if mpl.__version__ >= '3.1.0':
+            self.colorbar.update_normal(self.image)
+        else:
+            self.colorbar.set_norm(self.norm)
+            self.colorbar.update_bruteforce(self.image)
 
     def grid_helper(self):
         """Define the locator used in skew transforms."""
@@ -3515,6 +3514,8 @@ class NXNavigationToolbar(NavigationToolbar):
         self.plotview.ytab.maxbox.setValue(ymax)
         self.plotview.ytab.set_sliders(ymin, ymax)
         self.plotview.ytab.block_signals(False)
+        if self.plotview.image:
+            self.plotview.update_colorbar()
         self.plotview.update_panels()
 
     def toggle_aspect(self):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -625,7 +625,7 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         Difference between maximum and minimum values when the box is
         locked.
     """
-    def __init__(self, slot=None):
+    def __init__(self, slot=None, editing=None):
         super(NXDoubleSpinBox, self).__init__()
         self.validator = QtGui.QDoubleValidator()
         self.validator.setRange(-np.inf, np.inf)
@@ -633,8 +633,9 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         self.old_value = None
         self.diff = None
         if slot:
-            self.valueChanged[six.text_type].connect(slot)    
-
+            self.valueChanged.connect(slot)
+        if editing:
+            self.editingFinished.connect(editing)
         self.setAlignment(QtCore.Qt.AlignRight)
         self.setFixedWidth(100)
         self.setKeyboardTracking(False)
@@ -647,7 +648,6 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             self.setValue(self.value() + steps * self.diff)
         else:
             super(NXDoubleSpinBox, self).stepBy(steps)
-        self.editingFinished.emit()
 
     def valueFromText(self, text):
         value = np.float32(text)
@@ -666,6 +666,14 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         elif value < self.minimum():
             self.setMinimum(value)
         super(NXDoubleSpinBox, self).setValue(value)
+        self.old_value = value
+
+    def focusOutEvent(self, event):
+        self.blockSignals(True)
+        super(NXDoubleSpinBox, self).focusOutEvent(event)
+        if self.old_value:
+            self.setValue(self.old_value)
+        self.blockSignals(False)
 
 
 class NXSlider(QtWidgets.QSlider):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -648,6 +648,7 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             self.setValue(self.value() + steps * self.diff)
         else:
             super(NXDoubleSpinBox, self).stepBy(steps)
+        self.old_value = self.value()
 
     def valueFromText(self, text):
         value = np.float32(text)

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -679,13 +679,12 @@ class NXSlider(QtWidgets.QSlider):
         True if the slot is triggered by moving the slider. Otherwise, 
         it is only triggered on release.
     """
-    def __init__(self, slot=None, move=True):
+    def __init__(self, slot=None, move=True, inverse=False):
         super(NXSlider, self).__init__(QtCore.Qt.Horizontal)
         self.setFocusPolicy(QtCore.Qt.NoFocus)
         self.setMinimumWidth(100)
-        self.setRange(0, 1000)
+        self.setRange(0, 100)
         self.setSingleStep(5)
-        self.setValue(0)
         self.setTracking(True)
         if slot:
             self.sliderReleased.connect(slot)

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -686,10 +686,30 @@ class NXSlider(QtWidgets.QSlider):
         self.setRange(0, 100)
         self.setSingleStep(5)
         self.setTracking(True)
+        self.inverse = inverse
+        if self.inverse:
+            self.setInvertedAppearance(True)
+            self.setValue(100)
+        else:
+            self.setInvertedAppearance(False)
+            self.setValue(0)
         if slot:
             self.sliderReleased.connect(slot)
             if move:    
                 self.sliderMoved.connect(slot)
+
+    def value(self):
+        _value = super(NXSlider, self).value()
+        if self.inverse:
+            return self.maximum() - _value
+        else:
+            return _value
+
+    def setValue(self, value):
+        if self.inverse:
+            super(NXSlider, self).setValue(self.maximum() - value)
+        else:
+            super(NXSlider, self).setValue(value)
 
 
 class NXpatch(object):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -487,12 +487,12 @@ class NXSpinBox(QtWidgets.QSpinBox):
         self.diff = None
         self.pause = False
         if slot:
-            self.valueChanged[six.text_type].connect(slot)
-
+            self.valueChanged.connect(slot)
         self.setAlignment(QtCore.Qt.AlignRight)
         self.setFixedWidth(100)
         self.setKeyboardTracking(False)
         self.setAccelerated(False)
+        self.app = QtWidgets.QApplication.instance()
 
     def value(self):
         """Return the value of the spin box.
@@ -604,7 +604,11 @@ class NXSpinBox(QtWidgets.QSpinBox):
                 super(NXSpinBox, self).stepBy(steps)
             else:
                 self.pause = True
-        self.valueChanged.emit(1)
+
+    def timerEvent(self, event):
+        self.app.processEvents()
+        if self.app.mouseButtons() & QtCore.Qt.LeftButton:
+            super(NXSpinBox, self).timerEvent(event)
 
 
 class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
@@ -639,6 +643,7 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         self.setAlignment(QtCore.Qt.AlignRight)
         self.setFixedWidth(100)
         self.setKeyboardTracking(False)
+        self.app = QtWidgets.QApplication.instance()
 
     def validate(self, input_value, position):
         return self.validator.validate(input_value, position)
@@ -675,6 +680,11 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         if self.old_value:
             self.setValue(self.old_value)
         self.blockSignals(False)
+
+    def timerEvent(self, event):
+        self.app.processEvents()
+        if self.app.mouseButtons() & QtCore.Qt.LeftButton:
+            super(NXDoubleSpinBox, self).timerEvent(event)
 
 
 class NXSlider(QtWidgets.QSlider):


### PR DESCRIPTION
* Improves slider performance to reduce latency of plot synchronization.
* Prevents changes to the axis limits unless the user presses [Return] after editing. This makes the change more intentional and also stops sliders from adjusting the overall axis limits.
* Fixes a timing issue causing the spin box arrows to trigger twice with each mouse press.
* Inverts the appearance of the minimum value slider to make it symmetric with the maximum value slider.
* Removes minor ticks from the color bar on a log scale. New NXPlotView functions allow minor axes to be turned on and off for both the main plot and the color bar.