### PR TITLE
Improve axis boxes

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1816,6 +1816,7 @@ class CustomizeTab(NXTab):
         parameters.add('offset', 0.0, 'Offset', slot=self.scale_plot,
                        spinbox=True)
         parameters['offset'].box.setSingleStep(10)
+        parameters['offset'].box.setMinimum(-parameters['offset'].box.maximum())
         parameters.grid(title='Plot Parameters', header=False, width=125)
         return parameters
 
@@ -1844,9 +1845,16 @@ class CustomizeTab(NXTab):
         plot = self.label_plot(self.plot_stack.box.selected)
         label = self.plot_label(plot)
         scale = self.parameters[label]['scale'].value
+        if scale == self.parameters[label]['scale'].box.maximum():
+            self.parameters[label]['scale'].box.setMaximum(10*scale)
         self.parameters[label]['scale'].box.setSingleStep(scale/100.0)
         offset = self.parameters[label]['offset'].value
-        self.parameters[label]['offset'].box.setSingleStep(max(offset/100.0, 1))
+        if offset == self.parameters[label]['offset'].box.maximum():
+            self.parameters[label]['offset'].box.setMaximum(10*abs(offset))
+        self.parameters[label]['offset'].box.setMinimum(
+            -self.parameters[label]['offset'].box.maximum()) 
+        self.parameters[label]['offset'].box.setSingleStep(
+            max(abs(offset)/100.0, 1))
         y = self.plotview.plots[plot]['y']
         self.plotview.plots[plot]['plot'].set_ydata((y * scale) + offset)
         self.plotview.draw()

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1253,6 +1253,17 @@ class NXPlotView(QtWidgets.QDialog):
                 self.plot_smooth()
             except NeXusError:
                 pass
+        else:
+            if self.autoscale:
+                logv = self.logv
+                try:
+                    self.vaxis.min = self.vaxis.lo = np.min(self.finite_v)
+                    self.vaxis.max = self.vaxis.hi = np.max(self.finite_v)
+                except:
+                    self.vaxis.min = self.vaxis.lo = 0.0
+                    self.vaxis.max = self.vaxis.hi = 0.1
+                self.vtab.set_axis(self.vaxis)
+                self.logv = logv
         if draw:
             self.draw()
         self.update_panels()
@@ -2402,6 +2413,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.aspect = 'auto'
             self.skew = None
             self.replot_data(newaxis=True)
+            self.vtab.set_axis(self.vaxis)
         self.update_panels()
         self.otab.update()
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2830,9 +2830,6 @@ class NXPlotTab(QtWidgets.QWidget):
         self.block_signals(True)
         hi = self.maxbox.value()
         if self.name == 'x' or self.name == 'y' or self.name == 'v':
-            if hi <= self.axis.lo:
-                hi = self.axis.lo + self.axis.min_range
-                self.maxbox.setValue(hi)
             self.axis.hi = hi
             if self.name == 'v' and self.symmetric:
                 self.axis.lo = -self.axis.hi
@@ -2882,9 +2879,6 @@ class NXPlotTab(QtWidgets.QWidget):
         self.block_signals(True)
         lo = self.minbox.value()
         if self.name == 'x' or self.name == 'y' or self.name == 'v':
-            if lo >= self.axis.hi:
-                lo = self.axis.hi - self.axis.min_range
-                self.minbox.setValue(lo)
             self.axis.lo = lo
             self.set_sliders(self.axis.lo, self.axis.hi)
             if self.name == 'v':

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2814,7 +2814,10 @@ class NXPlotTab(QtWidgets.QWidget):
         else:
             self.maxbox.old_value = self.maxbox.text()
         self.axis.hi = self.axis.max = self.maxbox.value()
-        if self.axis.hi <= self.axis.lo:
+        if self.name == 'v' and self.symmetric:
+            self.axis.lo = self.axis.min = -self.axis.hi
+            self.minbox.setValue(-self.axis.hi)
+        elif self.axis.hi <= self.axis.lo:
             self.axis.lo = self.axis.data.min()
             self.minbox.setValue(self.axis.lo)
         self.block_signals(True)

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -290,9 +290,10 @@ def find_nearest_index(array, value):
     return (np.abs(array-value)).argmin()
 
 
-def format_float(value):
+def format_float(value, width=6):
     """Modified form of the 'g' format specifier."""
-    return re.sub("e(-?)0*(\d+)", r"e\1\2", ("%g" % value).replace("e+", "e"))
+    text = "{:.{width}g}".format(value, width=width)
+    return re.sub("e(-?)0*(\d+)", r"e\1\2", text.replace("e+", "e"))
 
 
 def human_size(bytes):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -684,9 +684,10 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         return value
 
     def textFromValue(self, value):
-        text = "{:.8g}".format(value)
-        text = re.sub("e(-?)0*(\d+)", r"e\1\2", text.replace("e+", "e"))
-        return text
+        if value > 1e6:
+            return format_float(value)
+        else:
+            return format_float(value, width=8)
 
     def setValue(self, value):
         if value > self.maximum():


### PR DESCRIPTION
* Changes behavior of axis boxes so that the overall limits and slider sensitivity are only changed when the box values are edited manually. 
* Matches the number of decimal places in the axis boxes to the step size.
* Rounds the step size to make axis values more consistent.
* Turns on by default the Matplotlib feature switching to display offset values when the absolute value is much larger than the range.
* Fixes a bug in which the signal limits are not updated when changing plot axes.
* Fixes a bug preventing the offset from exceeding 1000 in the Customize Panel for 1D plots.