### PR TITLE
Minor fixes

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2262,6 +2262,9 @@ class ProjectionTab(NXTab):
             else:
                 self.overplot_box.setVisible(False)
                 self.overplot_box.setChecked(False)
+                projection.logv = self.plotview.logv
+                projection.cmap = self.plotview.cmap
+                projection.interpolation = self.plotview.interpolation
             projection.make_active()
             projection.raise_()
         except NeXusError as error:

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -2422,7 +2422,7 @@ class LimitDialog(NXPanel):
  
     def __init__(self, parent=None):
         super(LimitDialog, self).__init__('limit', title='Limits Panel', 
-              parent=parent)
+                                          apply=False, parent=parent)
         self.tab_class = LimitTab
         self.plotview_sort = True
 
@@ -2523,14 +2523,8 @@ class LimitTab(NXTab):
         self.maxbox['signal'].setRange(vaxis.min, vaxis.max)
         self.minbox['signal'].setValue(vaxis.lo)
         self.maxbox['signal'].setValue(vaxis.hi)
-        if self.ndim > 1:
-            self.copied_properties = {'aspect': self.plotview.aspect,
-                                      'cmap': self.plotview.cmap,
-                                      'interpolation': self.plotview.interpolation,
-                                      'logv': self.plotview.logv,
-                                      'logx': self.plotview.logx,
-                                      'logy': self.plotview.logy,
-                                      'skew': self.plotview.skew}
+        self.copied_properties = ['aspect', 'cmap', 'interpolation', 
+                                  'logv', 'logx', 'logy', 'skew']
         self.copywidget.setVisible(False)
         for tab in [self.tabs[label] for label in self.tabs 
                     if self.tabs[label] is not self]:
@@ -2640,7 +2634,6 @@ class LimitTab(NXTab):
             if (tab.copybox.selected == self.name and
                 tab.checkbox['sync'].isChecked()):
                 tab.copy()
-                tab.apply()
         self.sort_copybox()
 
     def update_limits(self):
@@ -2655,14 +2648,6 @@ class LimitTab(NXTab):
             figure_size = self.plotview.figure.get_size_inches()
             self.parameters['xsize'].value = figure_size[0]
             self.parameters['ysize'].value = figure_size[1]
-        if self.ndim > 1:
-            self.copied_properties = {'aspect': self.plotview.aspect,
-                                      'cmap': self.plotview.cmap,
-                                      'interpolation': self.plotview.interpolation,
-                                      'logv': self.plotview.logv,
-                                      'logx': self.plotview.logx,
-                                      'logy': self.plotview.logy,
-                                      'skew': self.plotview.skew}
 
     def copy(self):
         tab = self.tabs[self.copybox.selected]
@@ -2672,11 +2657,6 @@ class LimitTab(NXTab):
             self.lockbox[axis].setCheckState(tab.lockbox[axis].checkState())
         self.minbox['signal'].setValue(tab.minbox['signal'].value())
         self.maxbox['signal'].setValue(tab.maxbox['signal'].value())
-        if self.ndim > 1:
-            self.xbox.setCurrentIndex(tab.xbox.currentIndex())
-            self.ybox.setCurrentIndex(tab.ybox.currentIndex())
-            for p in self.copied_properties:
-                self.copied_properties[p] = getattr(tab.plotview, p)
         if self.plotview.label != 'Main':
             if tab.plotview.label == 'Main':
                 figure_size = tab.plotview.figure.get_size_inches()
@@ -2685,12 +2665,6 @@ class LimitTab(NXTab):
             else:
                 self.parameters['xsize'].value = tab.parameters['xsize'].value
                 self.parameters['ysize'].value = tab.parameters['ysize'].value
-
-    def reset(self):
-        self.plotview.otab.home()
-        self.update()
-
-    def apply(self):
         try:
             if self.ndim == 1:
                 xmin, xmax = self.minbox[0].value(), self.maxbox[0].value()
@@ -2729,15 +2703,19 @@ class LimitTab(NXTab):
                         self.plotview.ztab.set_axis(self.plotview.axis[idx])
                         self.plotview.ztab.set_limits(self.minbox[idx].value(),
                                                       self.maxbox[idx].value())
-                self.plotview.replot_data()
                 for p in self.copied_properties:
-                    setattr(self.plotview, p, self.copied_properties[p])
+                    setattr(self.plotview, p, getattr(tab.plotview, p))
+                self.plotview.replot_data()
             if self.plotview.label != 'Main':
                 xsize, ysize = (self.parameters['xsize'].value, 
                                 self.parameters['ysize'].value)
                 self.plotview.figure.set_size_inches(xsize, ysize)
         except NeXusError as error:
             report_error("Setting plot limits", error)
+
+    def reset(self):
+        self.plotview.otab.home()
+        self.update()
 
     def close(self):
         for tab in [self.tabs[label] for label in self.tabs 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -741,8 +741,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.replot_axes(draw=False)
 
         self.offsets = True
-        if cmap:
-            self.cmap = cmap
+        self.cmap = cmap
         self.aspect = self._aspect
 
         if self.ndim > 1 and log:
@@ -3117,6 +3116,8 @@ class NXPlotTab(QtWidgets.QWidget):
         If the color map is available but was not included in the 
         default list when NeXpy was launched, it is added to the list.
         """
+        if cmap is None:
+            cmap = self._cached_cmap
         cm = get_cmap(cmap)
         cmap = cm.name
         if cmap != self._cached_cmap:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -743,8 +743,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.offsets = True
         if cmap:
             self.cmap = cmap
-        if self.aspect != 'auto':
-            self.aspect = self._aspect
+        self.aspect = self._aspect
 
         if self.ndim > 1 and log:
             self.logv = log
@@ -1525,12 +1524,12 @@ class NXPlotView(QtWidgets.QDialog):
                 self.otab._actions['set_aspect'].setChecked(True)
             else:
                 self._aspect = 'auto'
-        try:
-            self.ax.set_aspect(self._aspect)
-            self.canvas.draw()
-        except:
-            pass
-        self.update_tabs()
+        if self._aspect != self.ax.get_aspect():
+            try:
+                self.ax.set_aspect(self._aspect)
+                self.canvas.draw()
+            except:
+                pass
 
     aspect = property(_aspect, _set_aspect, "Property: Aspect ratio value")
 
@@ -1580,7 +1579,6 @@ class NXPlotView(QtWidgets.QDialog):
             self.ax.set_aspect(self._aspect)
         if self.image is not None:
             self.replot_data(newaxis=True)
-            self.update_tabs()
 
     skew = property(_skew, _set_skew, "Property: Axis skew angle")
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1555,6 +1555,8 @@ class NXPlotView(QtWidgets.QDialog):
         skew_angle : float
             The angle between the x and y axes for a 2D plot.
         """
+        if skew_angle == self._skew_angle:
+            return
         try:
             _skew_angle = float(skew_angle)
             if self.skew is not None and np.isclose(self.skew, _skew_angle):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -549,6 +549,7 @@ class NXSpinBox(QtWidgets.QSpinBox):
 
     def setValue(self, value):
         super(NXSpinBox, self).setValue(self.valueFromText(value))
+        self.repaint()
 
     def valueFromText(self, text):
         return self.indexFromValue(float(six.text_type(text)))
@@ -698,6 +699,7 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         elif value < self.minimum():
             self.setMinimum(value)
         super(NXDoubleSpinBox, self).setValue(value)
+        self.repaint()
 
     def timerEvent(self, event):
         self.app.processEvents()

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -491,6 +491,7 @@ class NXSpinBox(QtWidgets.QSpinBox):
         self.pause = False
         if slot:
             self.valueChanged.connect(slot)
+            self.editingFinished.connect(slot)
         self.setAlignment(QtCore.Qt.AlignRight)
         self.setFixedWidth(100)
         self.setKeyboardTracking(False)
@@ -639,10 +640,12 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         self.validator.setDecimals(1000)
         self.old_value = None
         self.diff = None
-        if slot:
+        if slot and editing:
             self.valueChanged.connect(slot)
-        if editing:
             self.editingFinished.connect(editing)
+        elif slot:
+            self.valueChanged.connect(slot)
+            self.editingFinished.connect(slot)
         self.setAlignment(QtCore.Qt.AlignRight)
         self.setFixedWidth(100)
         self.setKeyboardTracking(False)


### PR DESCRIPTION
* Update plots immediately after copying values from another tab in the Limit Panel.
* Copy 2D plot settings for log scales, color maps, and interpolations to projection plots.
* Use previously set color maps in new plots.
* Fix bug where the aspect ratio is not initialized when set to 'equal' in the previous plot.
* Repaint axis box values after they are set programmatically, to fix a bug in recent versions of PyQt5 in MacOS.
