### PR TITLE
Improve setting fit limits

### DIFF
--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -934,7 +934,8 @@ class FitTab(NXTab):
             self.fitview.ytab.plotcombo.insert(num, num)
         
     def reset(self):
-        self.remove_plots()
+        self.reset_limits()
+        self.plot_data()
 
     def close(self):
         if self.plotview:

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -751,6 +751,7 @@ class FitTab(NXTab):
     def reset_limits(self):
         self.plot_minbox.setText(format_float(self.plot_min))
         self.plot_maxbox.setText(format_float(self.plot_max))
+        self.fitview.reset_plot_limits()
 
     def data_not_plotted(self):
         return self.data_label not in [self.fitview.plots[p]['label'] 
@@ -758,13 +759,15 @@ class FitTab(NXTab):
 
     def plot_data(self):
         if self.plotview is None:
-            self.fitview.plot(self.data, fmt='o', color=self.color)
+            self.fitview.plot(self._data, fmt='o', color=self.color)
+            self.fitview.set_plot_limits(*self.get_limits())
             for label in ['label', 'legend_label']:
                 self.fitview.plots[self.fitview.num][label] = self.data_label
             self.remove_plots()
         else:
             self.fitview.plot(self.data, fmt='o', color=self.color, over=True)
             self.fitview.plots[self.data_num]['plot'].set_color(self.color)
+            self.fitview.set_plot_limits(*self.get_limits())
             for label in ['label', 'legend_label']:
                 self.fitview.plots[self.fitview.num][label] = self.data_label
             num = self.fitview.num

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -745,6 +745,10 @@ class FitTab(NXTab):
             model_data = NXfield(y, name='Model')
         return NXdata(model_data, model_axis, title=self.data.nxtitle)
 
+    def set_limits(self, xmin, xmax):
+        self.plot_minbox.setText(format_float(xmin))
+        self.plot_maxbox.setText(format_float(xmax))
+
     def get_limits(self):
         return float(self.plot_minbox.text()), float(self.plot_maxbox.text())
 

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -599,13 +599,14 @@ class FitTab(NXTab):
             self.layout.insertLayout(2, self.remove_layout)
             self.layout.insertLayout(5, self.action_layout)
             self.plot_model_button.setVisible(True)
-            self.plotcombo.addItem('All')
+            self.plotcombo.add('All')
             self.plotcombo.insertSeparator(1)
             self.plotcombo.setVisible(True)
             self.plot_checkbox.setVisible(True)
         model_name = self.models[model_index]['name']
-        self.removecombo.addItem(self.expanded_name(model_name))
-        self.plotcombo.addItem(self.expanded_name(model_name))
+        self.removecombo.add(self.expanded_name(model_name))
+        self.removecombo.select(self.expanded_name(model_name))
+        self.plotcombo.add(self.expanded_name(model_name))
         self.first_time = False
 
     def add_model_rows(self, model_index): 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3590,22 +3590,28 @@ class NXNavigationToolbar(NavigationToolbar):
             if self.plotview.ndim > 1 and self.plotview.label != "Projection":
                 self.plotview.tab_widget.setCurrentWidget(self.plotview.ptab)
         elif event.button == 3:
-            if self.plotview.ndim == 1 or not event.inaxes:
-                self.home()
+            if not event.inaxes:
+                self.home(autoscale=False)
             elif (self.plotview.xp and self.plotview.yp and
                   abs(event.x - self.plotview.xp) < 5 and
                   abs(event.y - self.plotview.yp) < 5):
                 self.home(autoscale=False)
             elif self.plotview.xdata and self.plotview.ydata:
-                self.plotview.ptab.open_panel()
                 xmin, xmax = sorted([event.xdata, self.plotview.xdata])
                 ymin, ymax = sorted([event.ydata, self.plotview.ydata])
-                panel = self.plotview.panels['Projection']
-                tab = panel.tabs[self.plotview.label]
-                tab.minbox[self.plotview.xaxis.dim].setValue(xmin)
-                tab.maxbox[self.plotview.xaxis.dim].setValue(xmax)
-                tab.minbox[self.plotview.yaxis.dim].setValue(ymin)
-                tab.maxbox[self.plotview.yaxis.dim].setValue(ymax)
+                if self.plotview.ndim == 1:
+                    panels = self.plotview.panels
+                    if ('Fit' in panels and 
+                        self.plotview is panels['Fit'].tab.fitview):
+                        panels['Fit'].tab.set_limits(xmin, xmax)
+                else:
+                    self.plotview.ptab.open_panel()
+                    panel = self.plotview.panels['Projection']
+                    tab = panel.tabs[self.plotview.label]
+                    tab.minbox[self.plotview.xaxis.dim].setValue(xmin)
+                    tab.maxbox[self.plotview.xaxis.dim].setValue(xmax)
+                    tab.minbox[self.plotview.yaxis.dim].setValue(ymin)
+                    tab.maxbox[self.plotview.yaxis.dim].setValue(ymax)
         self.release(event)
 
     def release_pan(self, event):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -310,7 +310,7 @@ class NXComboBox(QtWidgets.QComboBox):
         """
         for item in items:
             if item not in self:
-                self.addItem(item)
+                self.addItem(str(item))
 
     def insert(self, idx, item):
         """Insert item at the specified index.


### PR DESCRIPTION
* Right-click dragging on the plot now sets the fitting limits, e.g., to facilitate 'guessing' parameters..
* Changes the NXPanel reset button to both remove model plots and reset the fitting limits.
* Selects the last model to be added  in the 'Remove Model' pull-down menu.