### PR TITLE
Reorganization of dialogs

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -3270,12 +3270,32 @@ class ScanTab(NXTab):
             pass
 
 
-class ViewDialog(NXDialog):
+class ViewDialog(NXPanel):
     """Dialog to view a NeXus field"""
+
+    def __init__(self, parent=None):
+        super(ViewDialog, self).__init__('View', title='View Panel', 
+                                         apply=False, reset=False, 
+                                         parent=parent)
+        self.tab_class = ViewTab
+
+    def activate(self, node):
+        label = node.nxroot.nxname + node.nxpath
+        if label not in self.tabs:
+            tab = ViewTab(node, parent=self)
+            self.add(label, tab, idx=self.idx(label))
+        else:
+            self.tab = label
+        self.setVisible(True)
+        self.raise_()
+        self.activateWindow()
+
+
+class ViewTab(NXTab):
 
     def __init__(self, node, parent=None):
 
-        super(ViewDialog, self).__init__(parent)
+        super(ViewTab, self).__init__(parent)
 
         self.node = node
         self.spinboxes = []
@@ -3334,8 +3354,6 @@ class ViewDialog(NXDialog):
         if target_error:
             layout.addWidget(NXLabel(target_error))
         
-        layout.addStretch()
-
         if node.attrs:
             self.attributes = GridParameters()
             for attr in node.attrs:
@@ -3343,21 +3361,15 @@ class ViewDialog(NXDialog):
             layout.addLayout(self.attributes.grid(header=False, 
                                                   title='Attributes', 
                                                   width=200))
-            layout.addStretch()
 
+        hlayout = QtWidgets.QHBoxLayout()
+        hlayout.addStretch()
+        hlayout.addLayout(layout)
         if (isinstance(node, NXfield) and node.shape is not None and 
                node.shape != () and node.shape != (1,)):
-            hlayout = QtWidgets.QHBoxLayout()
-            hlayout.addLayout(layout)
             hlayout.addLayout(self.table())
-            vlayout = QtWidgets.QVBoxLayout()
-            vlayout.addLayout(hlayout)
-            vlayout.addWidget(self.close_buttons(close=True))
-            vlayout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
-            self.setLayout(vlayout)          
-        else:
-            layout.addWidget(self.close_buttons(close=True))
-            self.setLayout(layout)
+        hlayout.addStretch()
+        self.setLayout(hlayout)
 
         self.setWindowTitle(node.nxroot.nxname+node.nxpath)
 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -748,7 +748,7 @@ class NXPanel(NXDialog):
             del self.tabs[label]
             removed_tab.deleteLater()
         if self.count == 0:
-            self.close()
+            self.setVisible(False)
 
     def idx(self, label):
         if self.plotview_sort and label in self.plotviews:

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1756,7 +1756,6 @@ class CustomizeTab(NXTab):
         self.markers, self.linestyles = markers, linestyles
 
         self.plotview = self.active_plotview
-        self.name = self.plotview.label
 
         self.parameters = {}
         pl = self.parameters['labels'] = GridParameters()
@@ -1792,9 +1791,6 @@ class CustomizeTab(NXTab):
                            self.plot_stack,
                            pg.grid(header=False))
         self.parameters['labels']['title'].box.setFocus()
-
-    def __repr__(self):
-        return 'CustomizeTab("%s")' % self.name
 
     def plot_label(self, plot):
         return str(plot) + ': ' + self.plots[plot]['label']

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1708,7 +1708,7 @@ class PreferencesDialog(NXDialog):
 class CustomizeDialog(NXPanel):
 
     def __init__(self, parent=None):
-        super(CustomizeDialog, self).__init__('customize', 
+        super(CustomizeDialog, self).__init__('Customize', 
                                               title='Customize Panel', 
                                               parent=parent)
         self.tab_class = CustomizeTab

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -183,13 +183,13 @@ class FitDialog(NXPanel):
         self.setMinimumWidth(850)        
         self.tab_class = FitTab
 
-    def activate(self, data, plotview=None, color='C0', parent=None):
+    def activate(self, data, plotview=None, color='C0'):
         if plotview:
             label = plotview.label + ': ' + str(plotview.num) 
         else:
             label = data.nxroot.nxname + data.nxpath
         if label not in self.tabs:
-            tab = FitTab(data, plotview=plotview, color=color, parent=parent)
+            tab = FitTab(data, plotview=plotview, color=color, parent=self)
             self.add(label, tab, idx=self.idx(label))
         else:
             self.tab = label

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -188,15 +188,8 @@ class FitDialog(NXPanel):
             label = plotview.label + ': ' + str(plotview.num) 
         else:
             label = data.nxroot.nxname + data.nxpath
-        if label not in self.tabs:
-            tab = FitTab(data, plotview=plotview, color=color, parent=self)
-            self.add(label, tab, idx=self.idx(label))
-        else:
-            self.tab = label
-            self.tab.update()
-        self.setVisible(True)
-        self.raise_()
-        self.activateWindow()
+        super(FitDialog, self).activate(label, data, plotview=plotview, 
+                                        color=color)
 
 
 class FitTab(NXTab):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -90,6 +90,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.settings = settings
         self.config = config
         self.copied_node = None
+        self.dialogs = []
 
         self.default_directory = os.path.expanduser('~')
         self.nexpy_dir = self.app.nexpy_dir
@@ -2049,14 +2050,15 @@ class MainWindow(QtWidgets.QMainWindow):
         new_plotview = NXPlotView(parent=self)
 
     def close_window(self):
-        close_types = (NXDialog, NXPlotView)
-        try:
-            for w in [w for w in set(self.app.app.topLevelWidgets())
-                      if isinstance(w, close_types) and w.isActiveWindow()]:              
-                w.close()
-                break
-        except Exception:
-            pass
+        windows = self.dialogs
+        windows += [self.plotviews[pv] for pv in self.plotviews if pv != 'Main']
+        for window in windows:
+            try:
+                if window.isActiveWindow():
+                    window.close()
+                    break
+            except Exception:
+                pass
 
     def equalize_windows(self):
         for label in [label for label in self.plotviews 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1601,8 +1601,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def view_data(self):
         try:
             node = self.treeview.get_node()
-            self.viewdialog = ViewDialog(node, parent=self)
-            self.viewdialog.show()
+            if 'View' not in self.panels:
+                self.panels['View'] = ViewDialog()
+            self.panels['View'].activate(node)
         except NeXusError as error:
             report_error("Viewing Data", error)
 

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -90,7 +90,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.settings = settings
         self.config = config
         self.copied_node = None
-        self.dialogs = []
 
         self.default_directory = os.path.expanduser('~')
         self.nexpy_dir = self.app.nexpy_dir
@@ -106,10 +105,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         rightpane = QtWidgets.QWidget()
 
+        self.dialogs = []
         self.panels = {}
         main_plotview = NXPlotView(label="Main", parent=self)
-        self.editors = NXScriptWindow(self)
-        self.editors.setVisible(False)
         self.log_window = None
         self._memroot = None
 
@@ -2145,7 +2143,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def show_scan_panel(self):
         if self.plotview.label == 'Projection':
-            if 'Scan' in self.panels and self.panels['Scan'].isVisible():
+            if 'Scan' in self.panels:
                 self.panels['Scan'].raise_()
                 self.panels['Scan'].activateWindow()
             return
@@ -2157,18 +2155,26 @@ class MainWindow(QtWidgets.QMainWindow):
             report_error("Showing Scan Panel", error)
 
     def show_script_window(self):
-        if self.editors.tabs.count() == 0:
+        if 'Editor' in self.panels:
+            self.panels['Editor'].raise_()
+            self.panels['Editor'].activateWindow()
+            return
+        if 'Editor' not in self.panels:
+            self.panels['Editor'] = NXScriptWindow()
+        if self.panels['Editor'].count == 0:
             self.new_script()
         else:
-            self.editors.setVisible(True)
-            self.editors.raise_()
+            self.panels['Editor'].raise_()    
+
+    def open_script_window(self, file_name):
+        if 'Editor' not in self.panels:
+            self.panels['Editor'] = NXScriptWindow()
+        self.panels['Editor'].activate(file_name)
 
     def new_script(self):
         try:
             file_name = None
-            editor = NXScriptEditor(file_name, parent=self)
-            self.editors.setVisible(True)
-            self.editors.raise_()
+            self.open_script_window(file_name)
             logging.info("Creating new script")
         except NeXusError as error:
             report_error("Editing New Script", error)
@@ -2181,9 +2187,7 @@ class MainWindow(QtWidgets.QMainWindow):
             file_name = getOpenFileName(self, 'Open Script', script_dir,
                                         file_filter)
             if file_name:
-                editor = NXScriptEditor(file_name, self)
-                self.editors.setVisible(True)
-                self.editors.raise_()
+                self.open_script_window(file_name)
                 logging.info("NeXus script '%s' opened" % file_name)
         except NeXusError as error:
             report_error("Editing Script", error)
@@ -2191,10 +2195,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def open_script_file(self):
         try:
             file_name = self.scripts[self.sender()]
-            dialog = NXScriptEditor(file_name, self)
-            dialog.show()
-            self.editors.setVisible(True)
-            self.editors.raise_()
+            self.open_script_window(file_name)
             logging.info("NeXus script '%s' opened" % file_name)
         except NeXusError as error:
             report_error("Opening Script", error)
@@ -2243,9 +2244,11 @@ class MainWindow(QtWidgets.QMainWindow):
         file_name = getOpenFileName(self, 'Open Script', script_dir,
                                     file_filter)
         if file_name:
+            if self.scriptwindow is None:
+                self.scriptwindow = NXScriptWindow(self)
             editor = NXScriptEditor(file_name, self)
-            self.editors.setVisible(True)
-            self.editors.raise_()
+            self.scriptwindow.setVisible(True)
+            self.scriptwindow.raise_()
             logging.info("NeXus script '%s' opened" % file_name)
 
     # minimize/maximize/fullscreen actions:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2390,6 +2390,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.console.execute("%quickref")
 
     def close_widgets(self):
+        self._app.processEvents()
         for widget in self._app.allWidgets():
             try:
                 if id(widget) != id(self):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2114,9 +2114,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def show_customize_panel(self):
         try:
-            if 'customize' not in self.panels:
-                self.panels['customize'] = CustomizeDialog()
-            self.panels['customize'].activate(self.active_plotview.label)
+            if 'Customize' not in self.panels:
+                self.panels['Customize'] = CustomizeDialog()
+            self.panels['Customize'].activate(self.active_plotview.label)
         except NeXusError as error:
             report_error("Showing Customize Panel", error)
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3559,12 +3559,12 @@ class NXNavigationToolbar(NavigationToolbar):
             self.plotview.grid(self.plotview._grid, self.plotview._minorgrid)
 
     def edit_parameters(self):
-        if 'customize' not in self.plotview.panels:
+        if 'Customize' not in self.plotview.panels:
             from .datadialogs import CustomizeDialog
-            self.plotview.panels['customize'] = CustomizeDialog()
-        self.plotview.panels['customize'].activate(self.plotview.label)
-        self.plotview.panels['customize'].setVisible(True)
-        self.plotview.panels['customize'].raise_()
+            self.plotview.panels['Customize'] = CustomizeDialog()
+        self.plotview.panels['Customize'].activate(self.plotview.label)
+        self.plotview.panels['Customize'].setVisible(True)
+        self.plotview.panels['Customize'].raise_()
 
     def add_data(self):
         keep_data(self.plotview.plotdata)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2350,7 +2350,7 @@ class NXPlotView(QtWidgets.QDialog):
                 self.tab_widget.removeTab(self.tab_widget.indexOf(self.vtab))
             else:
                 self.vtab.flipbox.setVisible(False)
-        for panel in list(self.panels):
+        for panel in self.panels:
             if self.label in self.panels[panel].tabs:
                 self.panels[panel].remove(self.label)
         self.block_signals(False)

--- a/src/nexpy/gui/scripteditor.py
+++ b/src/nexpy/gui/scripteditor.py
@@ -20,8 +20,9 @@ from pygments.formatter import Formatter
 
 from .pyqt import QtCore, QtGui, QtWidgets, getSaveFileName
 
+from .datadialogs import NXPanel, NXTab
 from .utils import confirm_action
-from .widgets import NXLabel, NXLineEdit
+from .widgets import NXLabel, NXLineEdit, NXPushButton
 
 
 def hex2QColor(c):
@@ -92,12 +93,11 @@ class NXScrollBar(QtWidgets.QScrollBar):
         if (self.signalsBlocked() and 
             change == QtWidgets.QAbstractSlider.SliderValueChange):
             self.blockSignals(False)
-        
 
 
 class NXPlainTextEdit(QtWidgets.QPlainTextEdit):
 
-    def __init__(self, parent):
+    def __init__(self, slot=None, parent=None):
         super(NXPlainTextEdit, self).__init__()
         self.setFont(QtGui.QFont('Courier'))
         self.setMinimumWidth(700)
@@ -108,6 +108,8 @@ class NXPlainTextEdit(QtWidgets.QPlainTextEdit):
         self.blockCountChanged.connect(parent.update_line_numbers)
         self.scrollbar = NXScrollBar(self)
         self.setVerticalScrollBar(self.scrollbar)
+        if slot:
+            self.scrollbar.valueChanged.connect(slot)
 
     def __repr__(self):
         return 'NXPlainTextEdit()'
@@ -117,63 +119,34 @@ class NXPlainTextEdit(QtWidgets.QPlainTextEdit):
         return self.blockCount()
 
        
-class NXScriptWindow(QtWidgets.QDialog):
+class NXScriptWindow(NXPanel):
 
     def __init__(self, parent=None):
-        super(NXScriptWindow, self).__init__(parent)
-        layout = QtWidgets.QVBoxLayout()
-        self.tabs = QtWidgets.QTabWidget(self)
-        layout.addWidget(self.tabs)
-        self.setLayout(layout)
-        self.setWindowTitle('Script Editor')
-        self.tabs.currentChanged.connect(self.update)
+        super(NXScriptWindow, self).__init__('Editor', title='Script Editor',
+                                             close=False, parent=parent)
+        self.tab_class = NXScriptEditor
 
     def __repr__(self):
         return 'NXScriptWindow()'
 
-    @property
-    def editors(self):
-        return [self.tabs.widget(idx) for idx in range(self.tabs.count())]
-
-    @property
-    def editor(self):
-        return self.tabs.currentWidget()
-
-    def update(self):
-        for editor in self.editors:
-            editor.adjustSize()
-        if self.tabs.count() == 0:
-            self.setVisible(False)
-
-    def closeEvent(self, event):
-        self.close()
-        event.accept()
-        
-    def close(self):
-        self.editor.close()
-        if self.tabs.count() == 0:
-            self.setVisible(False)
+    def activate(self, file_name):
+        if file_name:
+            label = os.path.basename(file_name)
+        else:
+            label = 'Untitled %s' % (self.count+1)
+        super(NXScriptWindow, self).activate(label, file_name)
 
 
-class NXScriptEditor(QtWidgets.QWidget):
+class NXScriptEditor(NXTab):
     """Dialog to plot arbitrary NeXus data in one or two dimensions"""
  
     def __init__(self, file_name=None, parent=None):
 
-        if parent is None:
-            from .consoleapp import _mainwindow
-            self.mainwindow = _mainwindow
-        else:
-            self.mainwindow = parent
-        self.window = self.mainwindow.editors
-
-        QtWidgets.QWidget.__init__(self, parent=self.window.tabs)
+        super(NXScriptEditor, self).__init__(parent=parent)
  
         self.file_name = file_name
         self.default_directory = self.mainwindow.script_dir
 
-        layout = QtWidgets.QVBoxLayout()
-        self.text_layout = QtWidgets.QHBoxLayout()
         self.number_box = QtWidgets.QPlainTextEdit('1')
         self.number_box.setFont(QtGui.QFont('Courier'))
         self.number_box.setStyleSheet(
@@ -184,61 +157,36 @@ class NXScriptEditor(QtWidgets.QWidget):
         self.number_box.setHorizontalScrollBarPolicy(
             QtCore.Qt.ScrollBarAlwaysOff)
         self.number_box.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.text_layout.addWidget(self.number_box)
-        self.text_box = NXPlainTextEdit(self)
-        self.text_box.scrollbar.valueChanged.connect(self.scroll_numbers)
-        self.text_layout.addWidget(self.text_box)
+        self.text_box = NXPlainTextEdit(slot=self.scroll_numbers,
+                                        parent=self)
+        self.text_layout = self.make_layout(self.number_box, self.text_box)
         self.text_layout.setSpacing(0)
-        layout.addLayout(self.text_layout)
         
-        run_button = QtWidgets.QPushButton('Run Script')
-        run_button.clicked.connect(self.run_script)
-        run_button.setAutoDefault(False)
-        self.argument_box = NXLineEdit()
-        self.argument_box.setMinimumWidth(200)
-        save_button = QtWidgets.QPushButton('Save')
-        save_button.clicked.connect(self.save_script)
-        save_as_button = QtWidgets.QPushButton('Save as...')
-        save_as_button.clicked.connect(self.save_script_as)
-        self.delete_button = QtWidgets.QPushButton('Delete')
-        self.delete_button.clicked.connect(self.delete_script)
-        close_button = QtWidgets.QPushButton('Close Tab')
-        close_button.clicked.connect(self.close)
-        button_layout = QtWidgets.QHBoxLayout()
-        button_layout.addWidget(run_button)
-        button_layout.addWidget(self.argument_box)
-        button_layout.addStretch()
-        button_layout.addWidget(save_button)
-        button_layout.addWidget(save_as_button)
-        button_layout.addWidget(self.delete_button)
-        button_layout.addWidget(close_button)
-        layout.addLayout(button_layout)
-        self.setLayout(layout)
+        run_button = NXPushButton('Run Script', self.run_script)
+        self.argument_box = NXLineEdit(width=200)
+        save_button = NXPushButton('Save', self.save_script)
+        save_as_button = NXPushButton('Save as...', self.save_script_as)
+        self.delete_button = NXPushButton('Delete', self.delete_script)
+        close_button = NXPushButton('Close Tab', self.panel.close)
+        button_layout = self.make_layout(run_button, self.argument_box,
+                                         'stretch', 
+                                         save_button, save_as_button,
+                                         self.delete_button, close_button)
+        self.set_layout(self.text_layout, button_layout)
 
         if self.file_name:
-            self.label = os.path.basename(self.file_name)
             with open(self.file_name, 'r') as f:
                 text = f.read()
             self.text_box.setPlainText(text)
-            self.window.tabs.addTab(self, self.label)
             self.update_line_numbers()
         else:
-            self.label = 'Untitled %s' % (self.window.tabs.count()+1)
             self.delete_button.setVisible(False)
-            self.window.tabs.addTab(self, self.label)
-        self.index = self.window.tabs.indexOf(self)
-
-        self.window.tabs.adjustSize()
-        self.window.tabs.setCurrentWidget(self)
 
         self.hl = Highlighter(self.text_box.document())
 
         self.text_box.setFocus()
         self.number_box.setFocusPolicy(QtCore.Qt.NoFocus)
 
-    def __repr__(self):
-        return 'NXScriptEditor(%s)' % self.label
-        
     def get_text(self):
         text = self.text_box.document().toPlainText().strip()
         return text.replace('\t', '    ')+'\n'
@@ -283,8 +231,7 @@ class NXScriptEditor(QtWidgets.QWidget):
             with open(file_name, 'w') as f:
                 f.write(self.get_text())
             self.file_name = file_name
-            self.window.tabs.setTabText(self.index, 
-                                        os.path.basename(self.file_name))
+            self.label = os.path.basename(self.file_name)
             self.mainwindow.add_script_action(self.file_name)
             self.delete_button.setVisible(True)
 
@@ -295,9 +242,4 @@ class NXScriptEditor(QtWidgets.QWidget):
                     "This cannot be reversed"):
                 os.remove(self.file_name)
                 self.mainwindow.remove_script_action(self.file_name)
-                self.close()
-
-    def close(self):
-        self.window.tabs.removeTab(self.index)
-        self.deleteLater()
-        self.window.update()
+                self.panel.close()


### PR DESCRIPTION
* Stores all NXDialog instances in a list to improve safety of window closures. Only NXDialog and NXPlotView windows are included in the search for active windows when `Ctrl+W` is invoked. 
* Allows the legend order in the Customize Panel to be modified.
* Converts ViewDialog to a tabbed interface.
* Converts NXScriptWindow to an NXPanel.
