### PR TITLE
Try simplified shutdown

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -797,12 +797,21 @@ class NXPanel(NXDialog):
                     self.tabs[tab].close()
         except Exception:
             pass
-        if self.panel in self.mainwindow.panels:
-            del self.mainwindow.panels[self.panel]
-        if self.panel in self.plotviews:
-            self.plotviews[self.panel].close()
-        if self in self.mainwindow.dialogs:
-            self.mainwindow.dialogs.remove(self)
+        try:
+            if self.panel in self.mainwindow.panels:
+                del self.mainwindow.panels[self.panel]
+        except Exception:
+            pass
+        try:
+            if self.panel in self.plotviews:
+                self.plotviews[self.panel].close()
+        except Exception:
+            pass
+        try:
+            if self in self.mainwindow.dialogs:
+                self.mainwindow.dialogs.remove(self)
+        except Exception:
+            pass
         event.accept()
 
     def close(self):

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2397,14 +2397,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 window.close()
             except:
                 pass        
-        self._app.processEvents()
-        for widget in self._app.allWidgets():
-            try:
-                if id(widget) != id(self):
-                    if widget.parent() is None:
-                        widget.close()
-            except:
-                pass          
 
     def closeEvent(self, event):
         """Customize the close process to confirm request to quit NeXpy."""


### PR DESCRIPTION
* Removes call to QApplication.allWidgets. 

This function is referenced in the stack trace whenever there is an intermittent crash on exit. Since NeXpy now explicitly closes all NXDialog and NXPlotView instances, the call to allWidgets may no longer be necessary. Preliminary tests on a Mac look promising, so this branch will allow testing on Linux.