### PR TITLE
Lazy loading

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1251,6 +1251,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.load_file(filename)
             except Exception:
                 pass
+        self.treeview.select_top()
+        self.treeview.setFocus()
 
     def reload(self):
         try:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1059,7 +1059,7 @@ class MainWindow(QtWidgets.QMainWindow):
                          % fname)
             return
         name = self.tree.get_name(fname)
-        self.tree[name] = nxload(fname)
+        self.tree[name] = nxload(fname, recursive=False)
         self.treeview.update()
         self.treeview.select_node(self.tree[name])
         self.treeview.setFocus()

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -304,7 +304,6 @@ class NXTreeView(QtWidgets.QTreeView):
 
     def update(self):
         super(NXTreeView, self).update()
-        self.selection_changed()
 
     def selection_changed(self):
         """Enable and disable menu actions based on the selection."""

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -522,6 +522,9 @@ class NXTreeView(QtWidgets.QTreeView):
             self.setCurrentIndex(idx)
         self.selectionModel().select(self.currentIndex(),
                                      QtCore.QItemSelectionModel.Select)
+
+    def select_top(self):
+        self.select_node(self.tree[self.tree.__dir__()[0]])
         
     def selectionChanged(self, new, old):
         super(NXTreeView, self).selectionChanged(new, old)

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -799,14 +799,9 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
     def setSingleStep(self, value):
         value = abs(value)
         if value == 0:
-            self.setDecimals(2)
             stepsize = 0.01
         else:
             digits = math.floor(math.log10(value))
-            if digits < 0:
-                self.setDecimals(-digits)
-            else:
-                self.setDecimals(2)
             multiplier = 10**digits
             stepsize = find_nearest(self.steps, value/multiplier) * multiplier
         super(NXDoubleSpinBox, self).setSingleStep(stepsize)
@@ -833,6 +828,14 @@ class NXDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             return format_float(value, width=8)
 
     def setValue(self, value):
+        if value == 0:
+            self.setDecimals(2)
+        else:
+            digits = math.floor(math.log10(abs(value)))
+            if digits < 0:
+                self.setDecimals(-digits)
+            else:
+                self.setDecimals(2)
         if value > self.maximum():
             self.setMaximum(value)
         elif value < self.minimum():


### PR DESCRIPTION
* Only loads entries in the top level of a NeXus file when it is initially opened. Entries for other groups are loaded as they are referenced or as the tree is expanded. 
* Adjusts the number of decimals for displaying double spin box values when edited manually.