### PR TITLE
Disable automatic gc

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -28,7 +28,8 @@ from .pyqt import QtCore, QtGui, QtWidgets
 
 from .mainwindow import MainWindow
 from .treeview import NXtree
-from .utils import NXConfigParser, NXLogger, timestamp_age, report_exception
+from .utils import (NXConfigParser, NXLogger, NXGarbageCollector,
+                    timestamp_age, report_exception)
 
 from nexusformat.nexus import NXroot, nxclasses, nxload, nxversion
 
@@ -274,6 +275,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
             self.icon_pixmap = None
         self.window = MainWindow(self, self.tree, self.settings, self.config)
         self.window.log = self.log
+        self.gc = NXGarbageCollector(self.window)
         global _mainwindow
         _mainwindow = self.window
 

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -29,7 +29,7 @@ from .pyqt import QtCore, QtGui, QtWidgets
 from .mainwindow import MainWindow
 from .treeview import NXtree
 from .utils import (NXConfigParser, NXLogger, NXGarbageCollector,
-                    timestamp_age, report_exception)
+                    timestamp_age, report_exception, initialize_preferences)
 
 from nexusformat.nexus import NXroot, nxclasses, nxload, nxversion
 
@@ -190,6 +190,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         """Initialize access to the NeXpy settings file."""
         self.settings_file = os.path.join(self.nexpy_dir, 'settings.ini')
         self.settings = NXConfigParser(self.settings_file)
+        initialize_preferences(self.settings)
         def backup_age(backup):
             try:
                 return timestamp_age(os.path.basename(os.path.dirname(backup)))

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -4453,6 +4453,7 @@ class ManageBackupsDialog(NXDialog):
             else:
                 self.mainwindow.settings.remove_option('backups', backup)
         self.mainwindow.settings.save()
+        self.scroll_area = NXScrollArea()
         items = []
         for backup in backups:
             date = format_timestamp(os.path.basename(os.path.dirname(backup)))
@@ -4462,11 +4463,14 @@ class ManageBackupsDialog(NXDialog):
                 self.checkboxes((backup, '%s: %s (%s)' 
                                          % (date, name, human_size(size)), 
                                  False), align='left'))
-        items.append(self.action_buttons(('Restore Files', self.restore),
-                                         ('Delete Files', self.delete)))
-        items.append(self.close_buttons(close=True))
+        self.scroll_widget = NXWidget()
+        self.scroll_widget.set_layout(*items)
+        self.scroll_area.setWidget(self.scroll_widget)
 
-        self.set_layout(*items)
+        self.set_layout(self.scroll_area, 
+                        self.action_buttons(('Restore Files', self.restore),
+                                            ('Delete Files', self.delete)),
+                        self.close_buttons(close=True))
 
         self.set_title('Manage Backups')
 

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1837,12 +1837,12 @@ class PreferencesDialog(NXDialog):
     def __init__(self, parent=None):
         super(PreferencesDialog, self).__init__(parent=parent, default=True)
         self.parameters = GridParameters()
-        self.parameters.add('memory', nxgetmemory(), 'Memory Limit')
+        self.parameters.add('memory', nxgetmemory(), 'Memory Limit (MB)')
         self.parameters.add('maxsize', nxgetmaxsize(), 'Array Size Limit')
         self.parameters.add('compression', nxgetcompression(), 
                             'Compression Filter')
         self.parameters.add('encoding', nxgetencoding(), 'Text Encoding')
-        self.parameters.add('lock', nxgetlock(), 'Lock Timeout')
+        self.parameters.add('lock', nxgetlock(), 'Lock Timeout (s)')
         self.set_layout(self.parameters.grid(), 
                         self.action_buttons(('Save As Default', 
                                             self.save_default)),

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -311,9 +311,7 @@ class NXWidget(QtWidgets.QWidget):
         return self.filename.text()
 
     def choose_directory(self):
-        """
-        Opens a file dialog and sets the directory text box to the chosen path.
-        """
+        """Opens a file dialog and sets the directory text box to the path."""
         dirname = self.get_default_directory()
         dirname = QtWidgets.QFileDialog.getExistingDirectory(self, 
                                                              'Choose Directory', 
@@ -323,13 +321,11 @@ class NXWidget(QtWidgets.QWidget):
             self.set_default_directory(dirname)
 
     def get_directory(self):
-        """
-        Returns the selected directory
-        """
+        """Return the selected directory."""
         return self.directoryname.text()
     
     def get_default_directory(self, suggestion=None):
-        '''return the most recent default directory for open/save dialogs'''
+        """Return the most recent default directory for open/save dialogs."""
         if suggestion is None or not os.path.exists(suggestion):
             suggestion = self.default_directory
         if os.path.exists(suggestion):
@@ -339,7 +335,7 @@ class NXWidget(QtWidgets.QWidget):
         return suggestion
     
     def set_default_directory(self, suggestion):
-        """Defines the default directory to use for open/save dialogs"""
+        """Defines the default directory to use for open/save dialogs."""
         if os.path.exists(suggestion):
             if not os.path.isdir(suggestion):
                 suggestion = os.path.dirname(suggestion)

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -56,6 +56,9 @@ class NXWidget(QtWidgets.QWidget):
         if parent is None:
             parent = self.mainwindow
         super(NXWidget, self).__init__(parent=parent)
+        self.initialize()
+
+    def initialize(self):
         self.treeview = self.mainwindow.treeview
         self.tree = self.treeview.tree
         self.plotview = self.mainwindow.plotview
@@ -563,8 +566,12 @@ class NXDialog(QtWidgets.QDialog, NXWidget):
     """Base dialog class for NeXpy dialogs"""
     
     def __init__(self, parent=None, default=False):
+        from .consoleapp import _mainwindow
+        self.mainwindow = _mainwindow
+        if parent is None:
+            parent = self.mainwindow
         QtWidgets.QDialog.__init__(self, parent=parent)
-        NXWidget.__init__(self, parent)
+        self.initialize()
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setSizeGripEnabled(True)
         self.mainwindow.dialogs.append(self)

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1123,6 +1123,8 @@ class GridParameter(object):
                 self.box.currentIndexChanged.connect(slot)
         else:
             if color:
+                if value == 'auto':
+                    value = None
                 self.colorbox = NXColorBox(value)
                 self.box = self.colorbox.textbox
             elif spinbox:

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -423,10 +423,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.file_menu.addSeparator()
 
-        self.print_action = QtWidgets.QAction("Print Shell",
+        self.preferences_action=QtWidgets.QAction("Edit Preferences",
             self,
-            triggered=self.print_action_console)
-        self.add_menu_action(self.file_menu, self.print_action, True)
+            triggered=self.edit_preferences
+            )
+        self.add_menu_action(self.file_menu, self.preferences_action)
 
         self.quit_action = QtWidgets.QAction("&Quit",
             self,
@@ -501,6 +502,14 @@ class MainWindow(QtWidgets.QMainWindow):
             triggered=self.select_all_console
             )
         self.add_menu_action(self.edit_menu, self.select_all_action, True)
+
+        self.edit_menu.addSeparator()
+
+        self.print_action = QtWidgets.QAction("Print Shell",
+            self,
+            triggered=self.print_action_console)
+        self.add_menu_action(self.edit_menu, self.print_action, True)
+
 
     def init_data_menu(self):
         self.data_menu = self.menu_bar.addMenu("Data")
@@ -868,13 +877,6 @@ class MainWindow(QtWidgets.QMainWindow):
             triggered=self.reset_axes
             )
         self.add_menu_action(self.window_menu, self.reset_limit_action)
-
-        self.preferences_action=QtWidgets.QAction("Edit Preferences",
-            self,
-            shortcut=QtGui.QKeySequence("Ctrl+Alt+E"),
-            triggered=self.edit_preferences
-            )
-#        self.add_menu_action(self.window_menu, self.preferences_action)
 
         self.window_menu.addSeparator()
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1097,8 +1097,8 @@ class NXPlotView(QtWidgets.QDialog):
         if self.data.nxroot.nxclass == "NXroot":
             return dirname(self.data.nxroot.nxname +
                            self.data.nxsignal.nxpath) + '/'
-        elif 'signal_path' in self.data.nxsignal.attrs:
-            return dirname(self.data.nxsignal.attrs['signal_path']) + '/'
+        elif 'signal_path' in self.data.attrs:
+            return dirname(self.data.attrs['signal_path']) + '/'
         else:
             return ''
 

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -20,7 +20,6 @@ from .utils import display_message, natural_sort, modification_time
 from .widgets import NXSortModel
 from nexusformat.nexus import *
 
-treeitems = []
 
 class NXtree(NXgroup):
     """
@@ -198,7 +197,6 @@ class NXTreeItem(QtGui.QStandardItem):
                 pkg_resources.resource_filename('nexpy.gui',
                                             'resources/unlock-red-icon.png'))
         super(NXTreeItem, self).__init__(node.nxname)
-        treeitems.append(self)
 
     @property
     def node(self):

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -488,6 +488,13 @@ def parula_map():
                [0.9763, 0.9831, 0.0538]]
     return LinearSegmentedColormap.from_list('parula', cm_data)
 
+def cmyk_to_rgb(c, m, y, k):
+    """Convert CMYK values to RGB values."""
+    r = int(255 * (1.0 - (c + k) / 100.))
+    g = int(255 * (1.0 - (m + k) / 100.))
+    b = int(255 * (1.0 - (y + k) / 100.))
+    return r, g, b
+
 def load_image(filename):
     if os.path.splitext(filename.lower())[1] in ['.png', '.jpg', '.jpeg',
                                                  '.gif']:
@@ -497,9 +504,13 @@ def load_image(filename):
         x = NXfield(range(z.shape[1]), name='x')
         if z.ndim > 2:
             rgba = NXfield(range(z.shape[2]), name='rgba')
-            data = NXdata(z, (y,x,rgba))
+            if len(rgba) == 3:
+                z.interpretation = 'rgb-image'
+            elif len(rgba) == 4:
+                z.interpretation = 'rgba-image'
+            data = NXdata(z, (y, x, rgba))
         else:        
-            data = NXdata(z, (y,x))
+            data = NXdata(z, (y, x))
     else:
         try:
             im = fabio.open(filename)

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -540,6 +540,30 @@ def load_image(filename):
     return data
 
 
+def initialize_preferences(settings):
+    if settings.has_option('preferences', 'memory'):
+        nxsetmemory(settings.get('preferences', 'memory'))
+    else:
+        settings.set('preferences', 'memory', nxgetmemory())
+    if settings.has_option('preferences', 'maxsize'):
+        nxsetmaxsize(settings.get('preferences', 'maxsize'))
+    else:
+        settings.set('preferences', 'maxsize', nxgetmaxsize())
+    if settings.has_option('preferences', 'compression'):
+        nxsetcompression(settings.get('preferences', 'compression'))
+    else:
+        settings.set('preferences', 'compression', nxgetcompression())
+    if settings.has_option('preferences', 'encoding'):
+        nxsetencoding(settings.get('preferences', 'encoding'))
+    else:
+        settings.set('preferences', 'encoding', nxgetencoding())
+    if settings.has_option('preferences', 'lock'):
+        nxsetlock(settings.get('preferences', 'lock'))
+    else:
+        settings.set('preferences', 'lock', nxgetlock())
+    settings.save()
+
+
 class NXimporter(object):
     def __init__(self, paths):
         self.paths = paths
@@ -572,16 +596,24 @@ class NXConfigParser(ConfigParser, object):
             r"(?P<option>.*?)\s*(?:(?P<vi>=)\s*(?P<value>.*))?$", re.VERBOSE)
         super(NXConfigParser, self).read(self.file)
         sections = self.sections()
-        if 'recent' not in sections:
-            self.add_section('recent')
-        if 'session' not in sections:
-            self.add_section('session')
         if 'backups' not in sections:
             self.add_section('backups')
         if 'plugins' not in sections:
             self.add_section('plugins')
+        if 'preferences' not in sections:
+            self.add_section('preferences')
+        if 'recent' not in sections:
+            self.add_section('recent')
+        if 'session' not in sections:
+            self.add_section('session')
         if 'recentFiles' in self.options('recent'):
             self.fix_recent()
+
+    def set(self, section, option, value=None):
+        if value is not None:
+            super(NXConfigParser, self).set(section, option, str(value))
+        else:
+            super(NXConfigParser, self).set(section, option)            
 
     def optionxform(self, optionstr):
         return optionstr


### PR DESCRIPTION
* Enables manual garbage collection to ensure that it is conducted in the main PyQt thread. Automatic garbage collection in subsidiary threads has been known to cause application crashes.
* Fixes a bug when initializing PyQt subclasses with multiple inheritance. This is allowed in PyQt5 but not in PySide2.
* Adds an "Edit Preferences" menu item to allow the default values of NeXus parameters, such as memory limits and compression filters, to be changed. 
* Adds support for using the NeXus `interpretation` attribute to define RGB and RGBA images.
* Makes the "Manage Backups" dialog scrollable.