### PR TITLE
Add recursion setting as a preference

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -36,11 +36,12 @@ except ImportError:
 from nexusformat.nexus import (NeXusError, NXgroup, NXfield, NXattr, 
                                NXlink, NXlinkgroup, NXlinkfield,
                                NXroot, NXentry, NXdata, NXparameters, nxload,
-                               nxgetmemory, nxsetmemory,
-                               nxgetmaxsize, nxsetmaxsize, 
                                nxgetcompression, nxsetcompression,
                                nxgetencoding, nxsetencoding,
-                               nxgetlock, nxsetlock)                              
+                               nxgetlock, nxsetlock,
+                               nxgetmaxsize, nxsetmaxsize, 
+                               nxgetmemory, nxsetmemory,
+                               nxgetrecursive, nxsetrecursive)
 
 from .utils import (confirm_action, display_message, report_error, 
                     import_plugin, convertHTML, natural_sort, wrap, human_size,
@@ -1844,6 +1845,8 @@ class PreferencesDialog(NXDialog):
                             'Compression Filter')
         self.parameters.add('encoding', nxgetencoding(), 'Text Encoding')
         self.parameters.add('lock', nxgetlock(), 'Lock Timeout (s)')
+        self.parameters.add('recursive', ['True', 'False'], 'File Recursion')
+        self.parameters['recursive'].value = str(nxgetrecursive())
         self.set_layout(self.parameters.grid(), 
                         self.action_buttons(('Save As Default', 
                                             self.save_default)),
@@ -1858,6 +1861,8 @@ class PreferencesDialog(NXDialog):
                                      nxgetcompression())
         self.mainwindow.settings.set('preferences', 'encoding', nxgetencoding())
         self.mainwindow.settings.set('preferences', 'lock', nxgetlock())
+        self.mainwindow.settings.set('preferences', 'recursive', 
+                                     nxgetrecursive())
         self.mainwindow.settings.save()
 
     def set_preferences(self):
@@ -1866,6 +1871,7 @@ class PreferencesDialog(NXDialog):
         nxsetcompression(self.parameters['compression'].value)
         nxsetencoding(self.parameters['encoding'].value)
         nxsetlock(self.parameters['lock'].value)
+        nxsetrecursive(self.parameters['recursive'].value)
 
     def accept(self):
         self.set_preferences()

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1061,7 +1061,7 @@ class MainWindow(QtWidgets.QMainWindow):
                          % fname)
             return
         name = self.tree.get_name(fname)
-        self.tree[name] = nxload(fname, recursive=False)
+        self.tree[name] = nxload(fname)
         self.treeview.update()
         self.treeview.select_node(self.tree[name])
         self.treeview.setFocus()

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -561,6 +561,10 @@ def initialize_preferences(settings):
         nxsetlock(settings.get('preferences', 'lock'))
     else:
         settings.set('preferences', 'lock', nxgetlock())
+    if settings.has_option('preferences', 'recursive'):
+        nxsetrecursive(settings.getboolean('preferences', 'recursive'))
+    else:
+        settings.set('preferences', 'recursive', nxgetrecursive())
     settings.save()
 
 


### PR DESCRIPTION
* Allows the user to set whether a file is opened recursively by default, using the 'Edit Preferences' dialog.