### PR TITLE
Restrict additions to recent files list

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1326,9 +1326,12 @@ class DirectoryDialog(NXDialog):
                 self.checkbox[f].setChecked(False)
 
     def accept(self):
-        for f in self.files:
+        for i, f in enumerate(self.files):
             fname = os.path.join(self.directory, f)
-            self.mainwindow.load_file(fname, wait=1)
+            if i == 0:
+                self.mainwindow.load_file(fname, wait=1)
+            else:
+                self.mainwindow.load_file(fname, wait=1, recent=False)
         self.treeview.select_top()
         super(DirectoryDialog, self).accept()
 


### PR DESCRIPTION
* Only adds the first file to the list of recent files when opening a directory
* Files are no longer added to the list of recent files when recovering a previous session.