### PR TITLE
Enable capture of multiple switches in MacOS Catalina

### DIFF
--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -133,7 +133,7 @@ def run_pythonw():
             cmd = [pythonw_path, 'nexpygui.py']
             env = os.environ.copy()
             if len(sys.argv) > 1:
-                cmd.append(*sys.argv[1:])
+                cmd.extend(sys.argv[1:])
             import subprocess
             result = subprocess.run(cmd, env=env, cwd=cwd)
             sys.exit(result.returncode)


### PR DESCRIPTION
* Fixes a bug stopping multiple switches from being applied to the relaunched 'pythonw' process. This only affects MacOS 10.15 and 10.16.