### PR TITLE
Fix backward compatibility with Matplotlib

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1990,9 +1990,12 @@ class CustomizeTab(NXTab):
                        'Grid Style')
         parameters.add('minorticks', ['On', 'Off'], 'Minor Ticks')
         parameters.add('cb_minorticks', ['On', 'Off'], 'Color Bar Minor Ticks')
-        parameters.add('badcolor', 
-                       get_color(self.plotview.image.cmap.get_bad()),
-                       'Bad Color', color=True)
+        try:
+            parameters.add('badcolor', 
+                           get_color(self.plotview.image.cmap.get_bad()),
+                           'Bad Color', color=True)
+        except AttributeError:
+            pass
         parameters.grid(title='Image Parameters', header=False, width=125)
         return parameters
 
@@ -2016,7 +2019,10 @@ class CustomizeTab(NXTab):
             p['cb_minorticks'].value = 'On'
         else:
             p['cb_minorticks'].value = 'Off'
-        p['badcolor'].value = get_color(self.plotview.image.cmap.get_bad())
+        try:
+            p['badcolor'].value = get_color(self.plotview.image.cmap.get_bad())
+        except AttributeError:
+            pass
 
     def plot_parameters(self, plot):
         p = self.plots[plot]
@@ -2198,7 +2204,8 @@ class CustomizeTab(NXTab):
             self.plotview._gridcolor = pi['gridcolor'].value
             self.plotview._gridstyle = [k for k, v in self.linestyles.items()
                                         if v == pi['gridstyle'].value][0]
-            self.plotview.image.cmap.set_bad(pi['badcolor'].value)
+            if 'badcolor' in pi:
+                self.plotview.image.cmap.set_bad(pi['badcolor'].value)
             #reset in case plotview.aspect changed by plotview.skew            
             self.plotview.skew = _skew_angle
             self.plotview.aspect = self.plotview._aspect

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2370,6 +2370,10 @@ class NXPlotView(QtWidgets.QDialog):
                 except AttributeError:
                     leg.draggable(True)
         else:
+            try:
+                kwargs['bad'] = self.image.cmap.get_bad()
+            except AttributeError:
+                pass
             pv.plot(self.plotdata, ax=ax, 
                     image=plotview.rgb_image, log=self.logv, 
                     vmin=self.vaxis.lo, vmax=self.vaxis.hi,
@@ -2377,8 +2381,7 @@ class NXPlotView(QtWidgets.QDialog):
                     ymin=self.yaxis.lo, ymax=self.yaxis.hi,
                     aspect=self.aspect, regular=self.regular_grid,
                     interpolation=self.interpolation, 
-                    cmap=self.cmap, bad=self.image.cmap.get_bad(), 
-                    colorbar=colorbar, **kwargs)
+                    cmap=self.cmap, colorbar=colorbar, **kwargs)
         if title:
             ax.set_title(self.ax.get_title())
         else:


### PR DESCRIPTION
* Checks for the availability of the MPL Colormap `get_bad` function, which was only introduced in v3.4.0.