### PR TITLE
Catch missing plot number exceptions

### DIFF
--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -992,12 +992,13 @@ class FitTab(NXTab):
         for m in self.models:
             group[m['name']] = self.get_model(m['name'])
             parameters = NXparameters(attrs={'model':m['class']})
-            for n,p in m['parameters'].items():
-                n = n.replace(m['model'].prefix, '')
-                parameters[n] = NXfield(p.value, error=p.stderr, 
-                                        initial_value=p.init_value,
-                                        min=str(p.min), max=str(p.max),
-                                        expr=p.expr)
+            for name in m['parameters']:
+                p = self.fit.params[name]
+                name = name.replace(m['model'].prefix, '')
+                parameters[name] = NXfield(p.value, error=p.stderr, 
+                                           initial_value=p.init_value,
+                                           min=str(p.min), max=str(p.max),
+                                           expr=p.expr)
             group[m['name']].insert(parameters)
         group['program'] = 'lmfit'
         group['version'] = lmfit_version

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -303,7 +303,7 @@ class FitTab(NXTab):
         self.plot_checkbox = NXCheckBox('Use Data Points')
         self.plot_checkbox.setVisible(False)
         self.mask_button = NXPushButton('Mask Data', self.mask_data)
-        self.clear_mask_button = NXPushButton('Clear Mask', self.clear_mask)
+        self.clear_mask_button = NXPushButton('Clear Masks', self.clear_masks)
         self.color_box = NXColorBox(get_color(color), label='Plot Color',
                                     width=100)
         self.plot_layout = self.make_layout(plot_data_button, 
@@ -481,7 +481,7 @@ class FitTab(NXTab):
         self.clear_mask_button.setVisible(True)
         self.fit_status.setText('Waiting to fit...')
 
-    def clear_mask(self):
+    def clear_masks(self):
         self._data['signal'].mask = np.ma.nomask
         self.remove_masks()
         self.clear_mask_button.setVisible(False)
@@ -882,7 +882,7 @@ class FitTab(NXTab):
     def plot_mask(self):
         mask_data = self.signal_mask()
         if mask_data:
-            if self.mask_num:
+            if self.mask_num in self.fitview.plots:
                 self.fitview.plots[self.mask_num]['plot'].remove()
                 del self.fitview.plots[self.mask_num]
             else:                
@@ -1091,7 +1091,7 @@ class FitTab(NXTab):
         self.fitview.draw()
 
     def remove_masks(self):
-        if self.mask_num:
+        if self.mask_num in self.fitview.plots:
             self.fitview.plots[self.mask_num]['plot'].remove()
             del self.fitview.plots[self.mask_num]
             self.fitview.ytab.plotcombo.remove(self.mask_num)
@@ -1101,10 +1101,10 @@ class FitTab(NXTab):
         for num in [n for n in self.plot_nums if n in self.fitview.plots]:
             self.fitview.plots[num]['plot'].remove()
             del self.fitview.plots[num]
-            self.fitview.ytab.plotcombo.remove(num)
         self.plot_nums = []
-        self.fitview.num = self.data_num
-        self.fitview.ytab.plotcombo.select(self.data_num)
+        if self.data_num in self.fitview.plots:
+            self.fitview.num = self.data_num
+            self.fitview.ytab.plotcombo.select(self.data_num)
         self.fitview.draw()
         self.fitview.update_panels()
    


### PR DESCRIPTION
* Ensures that the NXPlotView 'plots' dictionary contains a plot number before attempting to remove it in the Fit Panel.
* Renames the 'Clear Mask' button to 'Clear Masks' to remove ambiguity.
* Fixes parameters expressions when removing models.