### PR TITLE
Improve legends

### DIFF
--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -304,8 +304,7 @@ class FitTab(NXTab):
         self.plot_checkbox = NXCheckBox('Use Data Points')
         self.mask_button = NXPushButton('Mask Data', self.mask_data)
         self.clear_mask_button = NXPushButton('Clear Masks', self.clear_masks)
-        self.color_box = NXColorBox(get_color(color), label='Plot Color',
-                                    width=100)
+        self.color_box = NXColorBox(color, label='Plot Color', width=100)
         self.plot_layout = self.make_layout(plot_data_button, 
                                             self.plot_model_button,
                                             self.plot_combo, 

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -1244,8 +1244,9 @@ class FitTab(NXTab):
    
     def apply(self):
         self.remove_plots()
-        self.fitview.plot(self.get_model(), fmt='-', color=self.color, 
-                          over=True)
+        if self.model is not None:
+            self.fitview.plot(self.get_model(), fmt='-', color=self.color, 
+                              over=True)
         
     def close(self):
         self.fitview.canvas.mpl_disconnect(self.cid)

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -33,7 +33,7 @@ from nexusformat.nexus import (NeXusError, NXattr, NXdata, NXentry, NXfield,
 
 from .datadialogs import NXDialog, NXPanel, NXTab
 from .plotview import NXPlotView, linestyles
-from .utils import format_float, get_color, report_error, display_message
+from .utils import format_float, report_error, display_message
 from .widgets import (NXCheckBox, NXColorBox, NXComboBox, NXLabel, NXLineEdit,
                       NXMessageBox, NXPushButton, NXScrollArea, NXrectangle)
 
@@ -998,11 +998,13 @@ class FitTab(NXTab):
             self.fitview.plot(mask_data, over=True, num=self.mask_num, 
                               fmt='o', color='white', alpha=0.8)
             self.fitview.ytab.plotcombo.remove(self.mask_num)
-            self.fitview.plots[self.mask_num]['legend_label'] = 'Mask'
+            self.fitview.plots[self.mask_num]['legend_label'] = (
+                                                    f"{self.tab_label} Mask")
             self.fitview.plots[self.mask_num]['show_legend'] = False
             if self.fitview.plots[self.mask_num]['cursor']:
                 self.fitview.plots[self.mask_num]['cursor'].remove()
             self.fitview.plots[self.mask_num]['cursor'] = None
+            self.fitview.update_panels()
         self.remove_rectangle()
 
     def plot_model(self, model=False):
@@ -1031,21 +1033,25 @@ class FitTab(NXTab):
                               xmin=self.plot_min, xmax=self.plot_max,
                               over=True, num=num)
             if self.fitted:
-                self.fitview.plots[num]['legend_label'] = 'Fit'
+                self.fitview.plots[num]['legend_label'] = (
+                                                    f"{self.tab_label} Fit")
             else:
-                self.fitview.plots[num]['legend_label'] = 'Model'
+                self.fitview.plots[num]['legend_label'] = (
+                                                    f"{self.tab_label} Model")
         else:
             self.fitview.plot(self.get_model(model), color=self.color,
                               marker=None, linestyle=next(self.linestyle), 
                               xmin=self.plot_min, xmax=self.plot_max,
                               over=True, num=num)
-            self.fitview.plots[num]['legend_label'] = model_name
+            self.fitview.plots[num]['legend_label'] = (
+                                            f"{self.tab_label} {model_name}")
         self.fitview.plots[num]['show_legend'] = False
         self.fitview.set_plot_limits(xmin=xmin, xmax=xmax)
         self.plot_nums.append(num)
         self.fitview.ytab.plotcombo.remove(num)
         self.fitview.ytab.plotcombo.select(self.data_num)
         self.remove_rectangle()
+        self.fitview.update_panels()
         self.fitview.raise_()
 
     def next_plot_num(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1945,6 +1945,7 @@ class NXPlotView(QtWidgets.QDialog):
         path = opts.pop('path', False)
         group = opts.pop('group', False)
         signal = opts.pop('signal', False)
+        ax = opts.pop('ax', self.ax)
         if self.ndim != 1:
             raise NeXusError("Legends are only displayed for 1D plots")
         elif len(items) == 0:
@@ -1967,13 +1968,15 @@ class NXPlotView(QtWidgets.QDialog):
             labels = items[0]
         else:
             handles, labels = items
-        self._legend = self.ax.legend(handles, labels, **opts)
+        _legend = ax.legend(handles, labels, **opts)
         try:
-            self._legend.set_draggable(True)
+            _legend.set_draggable(True)
         except AttributeError:
-            self._legend.draggable(True)
-        self.draw()
-        return self._legend
+            _legend.draggable(True)
+        if ax == self.ax:
+            self.draw()
+            self._legend = _legend
+        return _legend
 
     def remove_legend(self):
         """Remove the legend."""
@@ -2481,18 +2484,7 @@ class NXPlotView(QtWidgets.QDialog):
                         zorder=p['zorder'], **kwargs)
                 over = True
             if self.ax.get_legend():
-                h, _ = self.ax.get_legend_handles_labels()
-                order = sorted(self.plots, 
-                               key=lambda x: self.plots[x]['legend_order'])
-                handles = [self.plots[i]['plot'] for i in order 
-                           if self.plots[i]['show_legend']]
-                labels = [self.plots[i]['legend_label'] for i in order
-                          if self.plots[i]['show_legend']]
-                leg = ax.legend(handles, labels)
-                try:
-                    leg.set_draggable(True)
-                except AttributeError:
-                    leg.draggable(True)
+                self.legend(ax=ax)
         else:
             pv.plot(self.plotdata, ax=ax, 
                     image=plotview.rgb_image, log=self.logv, 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -94,7 +94,6 @@ from .widgets import (NXCheckBox, NXcircle, NXComboBox, NXDoubleSpinBox,
 active_plotview = None
 plotview = None
 plotviews = {}
-colors = mpl.rcParams['axes.prop_cycle'].by_key()['color']
 register_cmap('parula', parula_map())
 register_cmap('divgray', divgray_map())
 cmaps = ['viridis', 'inferno', 'magma', 'plasma', #perceptually uniform
@@ -960,7 +959,7 @@ class NXPlotView(QtWidgets.QDialog):
 
         if fmt == '':
             if 'color' not in opts:
-                opts['color'] = colors[(self.num-1) % len(colors)]
+                opts['color'] = self.colors[(self.num-1) % len(self.colors)]
             if 'marker' not in opts:
                 opts['marker'] = 'o'
             if 'linestyle' not in opts and 'ls' not in opts:
@@ -1768,6 +1767,10 @@ class NXPlotView(QtWidgets.QDialog):
             If the requested color map is not available.
         """
         self.vtab.cmap = cmap
+
+    @property
+    def colors(self):
+        return mpl.rcParams['axes.prop_cycle'].by_key()['color']
 
     @property
     def bad(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -386,9 +386,9 @@ class NXPlotView(QtWidgets.QDialog):
         self._bad = 'black'
         self._legend = None
         self._grid = False
-        self._gridcolor = mpl.rcParams['grid.color']
-        self._gridstyle = mpl.rcParams['grid.linestyle']
-        self._gridwidth = mpl.rcParams['grid.linewidth']
+        self._gridcolor = None
+        self._gridstyle = None
+        self._gridwidth = None
         self._minorgrid = False
         self._majorlines = []
         self._minorlines = []
@@ -808,9 +808,7 @@ class NXPlotView(QtWidgets.QDialog):
         if logy:
             self.logy = logy
 
-        if self._grid:
-            self.grid(self._grid, self._minorgrid)
-        self.set_minorticks(default=True)
+        self.set_plot_defaults()
 
         self.draw()
         self.otab.push_current()
@@ -1866,6 +1864,16 @@ class NXPlotView(QtWidgets.QDialog):
         except Exception as error:
             pass
 
+    def set_plot_defaults(self):
+        self._grid = mpl.rcParams['axes.grid']
+        self._gridcolor = mpl.rcParams['grid.color']
+        self._gridstyle = mpl.rcParams['grid.linestyle']
+        self._gridwidth = mpl.rcParams['grid.linewidth']
+        self._minorgrid = False
+        if self._grid:
+            self.grid(self._grid, self._minorgrid)
+        self.set_minorticks(default=True)
+
     def set_minorticks(self, default=False):
         if default:
             self._minorticks = (mpl.rcParams['xtick.minor.visible'] or
@@ -2026,6 +2034,8 @@ class NXPlotView(QtWidgets.QDialog):
                 opts['color'] = self._gridcolor
             if minor:
                 ax.minorticks_on()
+            if self.ndim > 1:
+                self.ax.set_axisbelow(False)
             if self.skew:
                 self.draw_skewed_grid(minor=minor, **opts)
             else:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -84,7 +84,7 @@ from nexusformat.nexus import NeXusError, NXdata, NXentry, NXfield, NXroot
 from .. import __version__
 from .datadialogs import (CustomizeDialog, ExportDialog, LimitDialog, 
                           ProjectionDialog, ScanDialog)
-from .utils import (boundaries, centers, divgray_map, find_nearest,
+from .utils import (boundaries, centers, divgray_map, find_nearest, get_color,
                     fix_projection, iterable, keep_data, parula_map,
                     report_error, report_exception)
 from .widgets import (NXCheckBox, NXcircle, NXComboBox, NXDoubleSpinBox,
@@ -1128,7 +1128,7 @@ class NXPlotView(QtWidgets.QDialog):
         p['legend_label'] = p['label']
         p['show_legend'] = True
         p['legend_order'] = len(self.plots) + 1
-        p['color'] = p['plot'].get_color()
+        p['color'] = get_color(p['plot'].get_color())
         p['marker'] = p['plot'].get_marker()
         p['markersize'] = p['plot'].get_markersize()
         p['markerstyle'] = 'filled'

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -389,6 +389,7 @@ class NXPlotView(QtWidgets.QDialog):
         self._gridcolor = None
         self._gridstyle = None
         self._gridwidth = None
+        self._gridalpha = None
         self._minorgrid = False
         self._majorlines = []
         self._minorlines = []
@@ -1869,6 +1870,7 @@ class NXPlotView(QtWidgets.QDialog):
         self._gridcolor = mpl.rcParams['grid.color']
         self._gridstyle = mpl.rcParams['grid.linestyle']
         self._gridwidth = mpl.rcParams['grid.linewidth']
+        self._gridalpha = mpl.rcParams['grid.alpha']
         self._minorgrid = False
         if self._grid:
             self.grid(self._grid, self._minorgrid)
@@ -2020,6 +2022,10 @@ class NXPlotView(QtWidgets.QDialog):
             self._grid = not self._grid
         self._minorgrid = minor
         if self._grid:
+            if 'color' in opts:
+                self._gridcolor = opts['color']
+            else:
+                opts['color'] = self._gridcolor
             if 'linestyle' in opts:
                 self._gridstyle = opts['linestyle']
             else:
@@ -2028,14 +2034,13 @@ class NXPlotView(QtWidgets.QDialog):
                 self._gridwidth = opts['linewidth']
             else:
                 opts['linewidth'] = self._gridwidth
-            if 'color' in opts:
-                self._gridcolor = opts['color']
+            if 'alpha' in opts:
+                self._gridalpha = opts['alpha']
             else:
-                opts['color'] = self._gridcolor
+                opts['alpha'] = self._gridalpha
             if minor:
                 ax.minorticks_on()
-            if self.ndim > 1:
-                self.ax.set_axisbelow(False)
+            self.ax.set_axisbelow('line')
             if self.skew:
                 self.draw_skewed_grid(minor=minor, **opts)
             else:

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -33,6 +33,7 @@ from .pyqt import QtCore, QtWidgets, getOpenFileName
 
 from IPython.core.ultratb import ColorTB
 from matplotlib.colors import colorConverter, hex2color, rgb2hex
+from matplotlib import rcParams
 
 try:
     from astropy.convolution import Kernel
@@ -432,7 +433,7 @@ def get_color(color):
     return rgb2hex(colorConverter.to_rgb(color))
 
 
-def get_colors(n, first='#1f77b4', last='#d62728'):
+def get_colors(n, first=None, last=None):
     """Return a list of colors interpolating between the first and last.
 
     The function accepts both strings representing hex colors and tuples 
@@ -452,6 +453,10 @@ def get_colors(n, first='#1f77b4', last='#d62728'):
     colors : list
         A list of strings containing hex colors
     """
+    if first is None:
+        first = rcParams['axes.prop_cycle'].by_key()['color'][0]
+    if last is None:
+        last = rcParams['axes.prop_cycle'].by_key()['color'][-1]
     if not isinstance(first, tuple):
         first = hex2color(first)
     if not isinstance(last, tuple):
@@ -629,7 +634,6 @@ def initialize_preferences(settings):
 def set_style(style=None):
     from matplotlib.style import use
     if style == 'publication':
-        from matplotlib import rcParams
         use('default')
         rcParams['axes.titlesize'] = 24
         rcParams['axes.titlepad'] = 20

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -626,7 +626,7 @@ class NXColorBox(QtWidgets.QWidget):
         if label:
             self.layout.addStretch()
             self.layout.addWidget(NXLabel(label))
-        self.textbox = NXLineEdit(colors.to_hex(color.getRgbF()),
+        self.textbox = NXLineEdit(self.color_text,
                                   parent=parent, slot=self.update_color, 
                                   width=width, align='right')
         self.layout.addWidget(self.textbox)
@@ -656,7 +656,7 @@ class NXColorBox(QtWidgets.QWidget):
     def qcolor(self, text):
         """Create a QColor from a Matplotlib color."""
         qcolor = QtGui.QColor()
-        text = str(text)
+        text = get_color(text)
         if text.startswith('#') and len(text)==7:
             correct = '#0123456789abcdef'
             for char in text:

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -619,7 +619,7 @@ class NXColorBox(QtWidgets.QWidget):
             Parent of the color box.
         """
         super(NXColorBox, self).__init__(parent=parent)
-        self.color_text = color
+        self.color_text = get_color(color)
         color = self.qcolor(self.color_text)
         self.layout = QtWidgets.QHBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
* Adds legend options to use the full signal path, group, or name, in addition to a customized label.
* Allows the NXPlotView legend function to apply to PyPlot figures, whose `ax` instance is given as a keyword.
* Allows the addition of legends to the output of the `mpl_plot` function.
* Uses the correct grid defaults and 1D color cycler when the Matplotlib style is changed.
* Adds grid customization to 1D plots and includes the grid alpha value.