### PR TITLE
Use Virtual Datasets for multi-file scans

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -3273,13 +3273,13 @@ class ScanTab(NXTab):
         signal = self.plotview.data.nxsignal
         axes = self.plotview.data.nxaxes
         scan_shape = (len(self.scan_axis()),) + signal.shape
-        scan_field = NXfield(name='data', shape=scan_shape, dtype=signal.dtype)
-        scan_field._create_memfile()
         layout = h5.VirtualLayout(shape=scan_shape, dtype=signal.dtype)
         for i, f in enumerate(self.scan_files):
             signal = f[self.data_path].nxsignal
             layout[i] = h5.VirtualSource(signal.nxfilename, signal.nxfilepath,
                                          shape=signal.shape)
+        scan_field = NXfield(name='data', shape=scan_shape, dtype=signal.dtype)
+        scan_field._create_memfile()
         scan_field._memfile.create_virtual_dataset(
             'data', layout, fillvalue=signal.fillvalue)
         self.scan_data = NXdata(scan_field, [self.scan_axis()] + axes)


### PR DESCRIPTION
* Changes the Scan Panel to use virtual HDF5 datasets to create a complete multidimensional dataset with the scan variable as an additional axis.
* Creates a new NXdata group with the entire multidimensional dataset, not just a single plane. The Projection Panel can then be used to create arbitrary slices that include the new scan axis. 
* This NXdata group can be saved to the scratch workspace for pasting into a new NeXus file.