### PR TITLE
Update virtual field support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     nexusformat >= 0.7.1
     numpy
     scipy
-    h5py
+    h5py >= 2.9
     qtpy
     qtconsole
     ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Visualization
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,9 @@ gui_scripts =
 [options.extras_require]
 spec = spec2nexus
 fabio = fabio
-testing = pytest, pyqt5
+testing = 
+    pyqt5
+    pytest
 
 [bdist_rpm]
 requires = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ gui_scripts =
 [options.extras_require]
 spec = spec2nexus
 fabio = fabio
-testing = pytest
+testing = pytest, pyqt5
 
 [bdist_rpm]
 requires = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
     =src
 python_requires = >=3.7
 install_requires =
-    nexusformat >= 0.7.1
+    nexusformat >= 0.7.2
     numpy
     scipy
     h5py >= 2.9
@@ -58,9 +58,7 @@ gui_scripts =
 [options.extras_require]
 spec = spec2nexus
 fabio = fabio
-testing = 
-    pyqt5
-    pytest
+testing = pytest
 
 [bdist_rpm]
 requires = 

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -276,25 +276,27 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
             s = f"{_class}=nx.{_class}\n" + s
         exec(s, self.window.user_ns)
 
+        default_script = ["import sys\n",
+                          "import os\n",
+                          "import h5py as h5\n",
+                          "import numpy as np\n",
+                          "import numpy.ma as ma\n",
+                          "import scipy as sp\n",
+                          "import matplotlib as mpl\n",
+                          "mpl.use('{}')\n".format(QtVersion),
+                          "from matplotlib import pylab, mlab, pyplot\n",
+                          "plt = pyplot\n",
+                          "os.chdir(os.path.expanduser('~'))\n"]
         config_file = os.path.join(self.nexpy_dir, 'config.py')
         if not os.path.exists(config_file):
-            s = ["import sys\n",
-                 "import os\n",
-                 "import h5py as h5\n",
-                 "import numpy as np\n",
-                 "import numpy.ma as ma\n",
-                 "import scipy as sp\n",
-                 "import matplotlib as mpl\n",
-                 "mpl.use('{}')\n".format(QtVersion),
-                 "from matplotlib import pylab, mlab, pyplot\n",
-                 "plt = pyplot\n",
-                 "os.chdir(os.path.expanduser('~'))\n"]
             with open(config_file, 'w') as f:
-                f.writelines(s)
-        else:
-            with open(config_file) as f:
-                s = f.readlines()
-        exec('\n'.join(s), self.window.user_ns)
+                f.writelines(default_script)
+        with open(config_file) as f:
+            s = f.readlines()
+        try:
+            exec('\n'.join(s), self.window.user_ns)
+        except Exception:
+            exec('\n'.join(default_script), self.window.user_ns)
         self.window.read_session()
         for i, filename in enumerate(args.filenames):
             try:

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1527,6 +1527,7 @@ class PlotScalarDialog(NXDialog):
                 ('over', 'Plot Over', False)),
             self.action_buttons(
                 ('Plot', self.plot_scan),
+                ('Copy', self.copy_scan),
                 ('Save', self.save_scan)),
             self.close_layout())
 
@@ -1680,6 +1681,13 @@ class PlotScalarDialog(NXDialog):
             self.get_scan().plot(**opts)
         except NeXusError as error:
             report_error("Plotting Scan", error)
+
+    def copy_scan(self):
+        try:
+            self.mainwindow.copied_node = self.mainwindow.copy_node(
+                self.get_scan())
+        except NeXusError as error:
+            report_error("Copying Scan", error)
 
     def save_scan(self):
         try:
@@ -2612,8 +2620,7 @@ class ProjectionTab(NXTab):
 
     def save_projection(self):
         try:
-            projection = self.get_projection()
-            keep_data(projection)
+            keep_data(self.get_projection())
         except NeXusError as error:
             report_error("Saving Projection", error)
 
@@ -3133,6 +3140,7 @@ class ScanTab(NXTab):
             self.action_buttons(('Select Scan', self.select_scan),
                                 ('Select Files', self.select_files)),
             self.action_buttons(('Plot', self.plot_scan),
+                                ('Copy', self.copy_scan),
                                 ('Save', self.save_scan)))
         self.file_box = None
         self.scan_files = None
@@ -3268,6 +3276,13 @@ class ScanTab(NXTab):
             self.scanview.raise_()
         except NeXusError as error:
             report_error("Plotting Scan", error)
+
+    def copy_scan(self):
+        try:
+            self.mainwindow.copied_node = self.mainwindow.copy_node(
+                self.scan_data)
+        except NeXusError as error:
+            report_error("Copying Scan", error)
 
     def save_scan(self):
         try:

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -3555,7 +3555,7 @@ class RemoteDialog(NXDialog):
     def __init__(self, parent=None):
 
         try:
-            import h5pyd
+            # import h5pyd
             from nexusformat.nexus import nxgetdomain, nxgetserver
         except ImportError:
             raise NeXusError("Please install h5pyd for remote data access")

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -961,9 +961,9 @@ class NXSlider(QtWidgets.QSlider):
 
     def setValue(self, value):
         if self.inverse:
-            super().setValue(self.maximum() - value)
+            super().setValue(self.maximum() - int(value))
         else:
-            super().setValue(value)
+            super().setValue(int(value))
 
 
 class NXpatch(object):


### PR DESCRIPTION
* Simplifies the Scan Panel data creation using the `nexusformat` function `nxconsolidate`.
* Adds a `Copy` button to the Scan Panel and the PlotScalarDialog to add the scanned data to the `Mainwindow` copy buffer for pasting to another NeXus tree. This helps keep the scratch workspace clean.
* Explicitly deletes the temporary scan file when closing the Scan Panel.
* Updates the required `h5py` version to 2.9 to ensure that virtual datasets are supported.
* Catches exceptions in the NeXpy startup script to ensure a successful launch.
* Advertises support for Python 3.10.