### PR TITLE
Catch exceptions when closing NeXus files

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2365,7 +2365,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def close_files(self):
         for root in [n for n in self.user_ns
                      if isinstance(self.user_ns[n], NXroot)]:
-            self.user_ns[root].close()
+            try:
+                self.user_ns[root].close()
+            except Exception:
+                pass
 
     def close_widgets(self):
         windows = self.dialogs


### PR DESCRIPTION
* Prevents an exception when shutting the application down if a NeXus file is already closed.