### PR TITLE
Update requirements for nexusformat

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexpy
-  version: "0.14.4"
+  version: "0.14.5"
 
 source:
   git_url: https://github.com/nexpy/nexpy.git
-  git_tag: v0.14.4
+  git_tag: v0.14.5
 
 build:
   entry_points:
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python >=3.7
-    - nexusformat >=0.7.1
+    - nexusformat >=0.7.5
     - numpy
     - scipy
     - h5py

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ package_dir =
     =src
 python_requires = >=3.7
 install_requires =
-    nexusformat >= 0.7.4
+    nexusformat >= 0.7.5
     numpy
     scipy
     h5py >= 2.9


### PR DESCRIPTION
* Updates the required nexusformat version to >=0.7.5, which adds a lock expiry time.