### PR TITLE
Add PyQt6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NeXpy GUI
 ---------
 The GUI is built using PyQt. The 
 [qtpy package](https://github.com/spyder-ide/qtpy) is used to import the 
-installed PyQt library, either PyQt5 or PySide2.
+installed PyQt library, either PyQt5, PyQt6, PySide2, or PySide6.
 
 The GUI includes an [IPython shell](http://ipython.org/) and a 
 [Matplotlib plotting pane](http://matplotlib.sourceforge.net). The IPython shell 

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ NeXpy GUI
 ---------
 The GUI is built using the PyQt. The 
 `qtpy package <https://github.com/spyder-ide/qtpy>`_ is used to import an 
-installed PyQt library, either PyQt5 or PySide2.
+installed PyQt library, either PyQt5, PyQt6, PySide2, or PySide6.
 
 The GUI includes an `IPython shell <http://ipython.org/>`_ and a `Matplotlib
 plotting pane <http://matplotlib.sourceforge.net>`_. The IPython shell is

--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -215,7 +215,7 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
         logging.info('Log level is ' + level)
         logging.info('Python ' + sys.version.split()[0] + ': '
                      + sys.executable)
-        logging.info(QtVersion + ' v' + QtCore.__version__)
+        logging.info(QtVersion)
         logging.info('IPython v' + ipython_version)
         logging.info('Matplotlib v' + mpl_version)
         logging.info('NeXpy v' + nexpy_version)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -32,10 +32,10 @@ import matplotlib as mpl
 import numpy as np
 from matplotlib.backend_bases import (FigureCanvasBase, FigureManagerBase,
                                       NavigationToolbar2)
-from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
-from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg as
-                                                FigureCanvas)
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+from matplotlib.backends.backend_qt import FigureManagerQT as FigureManager
+from matplotlib.backends.backend_qtagg import (FigureCanvasQTAgg as
+                                               FigureCanvas)
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 from matplotlib.figure import Figure
 from matplotlib.image import imread

--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -10,16 +10,16 @@ import os
 from qtpy import QtCore, QtGui, QtWidgets
 
 if QtCore.PYQT5:
-    QtVersion = 'PyQt5'
+    QtVersion = 'PyQt5' + ' v' + QtCore.__version__
     os.environ['QT_API'] = 'pyqt5'
 elif QtCore.PYQT6:
-    QtVersion = 'PyQt6'
+    QtVersion = 'PyQt6' + ' v' + QtCore.__version__
     os.environ['QT_API'] = 'pyqt6'
 elif QtCore.PYSIDE2:
-    QtVersion = 'PySide2'
+    QtVersion = 'PySide2' + ' v' + QtCore.__version__
     os.environ['QT_API'] = 'pyside2'
 elif QtCore.PYSIDE6:
-    QtVersion = 'PySide6'
+    QtVersion = 'PySide6' + ' v' + QtCore.__version__
     os.environ['QT_API'] = 'pyside6'
 
 

--- a/src/nexpy/gui/pyqt.py
+++ b/src/nexpy/gui/pyqt.py
@@ -12,9 +12,15 @@ from qtpy import QtCore, QtGui, QtWidgets
 if QtCore.PYQT5:
     QtVersion = 'PyQt5'
     os.environ['QT_API'] = 'pyqt5'
+elif QtCore.PYQT6:
+    QtVersion = 'PyQt6'
+    os.environ['QT_API'] = 'pyqt6'
 elif QtCore.PYSIDE2:
     QtVersion = 'PySide2'
     os.environ['QT_API'] = 'pyside2'
+elif QtCore.PYSIDE6:
+    QtVersion = 'PySide6'
+    os.environ['QT_API'] = 'pyside6'
 
 
 def getOpenFileName(*args, **kwargs):


### PR DESCRIPTION
* Updates the Qt imports to accept both PyQt6 and PySide6 libraries.
* Adds the specific PyQt version number to `QtVersion`, which can be imported from `nexpy.gui.pyqt`.