### PR TITLE
Initialize envs

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1854,13 +1854,19 @@ class LockDialog(NXDialog):
 
         self.show_locks()
 
+    def convert_name(self, name):
+        return '/' + name.replace('!!', '/')
+
     def show_locks(self):
+
         def _getmtime(entry):
             return entry.stat().st_mtime
+
         text = []
         for f in sorted(os.scandir(self.lockdirectory), key=_getmtime):
             if f.name.endswith('.lock'):
-                text.append(f'{format_mtime(f.stat().st_mtime)} {f.name}')
+                name = self.convert_name(f.name)
+                text.append(f'{format_mtime(f.stat().st_mtime)} {name}')
         if text:
             self.text_box.setPlainText('\n'.join(text))
         else:
@@ -1873,7 +1879,8 @@ class LockDialog(NXDialog):
         locks = []
         for f in sorted(os.scandir(self.lockdirectory), key=_getmtime):
             if f.name.endswith('.lock'):
-                locks.append(self.checkboxes((f.name, f.name, False),
+                name = self.convert_name(f.name)
+                locks.append(self.checkboxes((f.name, name, False),
                                              align='left'))
         dialog.scroll_area = NXScrollArea()
         dialog.scroll_widget = NXWidget()

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -610,43 +610,40 @@ def load_image(filename):
 
 
 def initialize_preferences(settings):
-    cfg = nxgetconfig()
-    if settings.has_option('preferences', 'memory'):
-        nxsetconfig(memory=settings.get('preferences', 'memory'))
-    else:
-        settings.set('preferences', 'memory', cfg['memory'])
-    if settings.has_option('preferences', 'maxsize'):
-        nxsetconfig(maxsize=settings.get('preferences', 'maxsize'))
-    else:
-        settings.set('preferences', 'maxsize', cfg['maxsize'])
-    if settings.has_option('preferences', 'compression'):
-        nxsetconfig(compression=settings.get('preferences', 'compression'))
-    else:
-        settings.set('preferences', 'compression', cfg['compression'])
-    if settings.has_option('preferences', 'encoding'):
-        nxsetconfig(encoding=settings.get('preferences', 'encoding'))
-    else:
-        settings.set('preferences', 'encoding', cfg['encoding'])
-    if settings.has_option('preferences', 'lock'):
-        nxsetconfig(lock=settings.get('preferences', 'lock'))
-    else:
-        settings.set('preferences', 'lock', cfg['lock'])
-    if settings.has_option('preferences', 'lockexpiry'):
-        nxsetconfig(lockexpiry=settings.get('preferences', 'lockexpiry'))
-    else:
-        settings.set('preferences', 'lockexpiry', cfg['lockexpiry'])
-    if settings.has_option('preferences', 'lockdirectory'):
-        nxsetconfig(lockdirectory=settings.get('preferences', 'lockdirectory'))
-    else:
-        settings.set('preferences', 'lockdirectory', cfg['lockdirectory'])
-    if settings.has_option('preferences', 'recursive'):
-        nxsetconfig(recursive=settings.getboolean('preferences', 'recursive'))
-    else:
-        settings.set('preferences', 'recursive', cfg['recursive'])
+    """Initialize NeXpy preferences.
+
+    For the nexusformat configuration parameters, precedence is given to
+    those that are defined by environment variables, since these might
+    be set by the system administrator. If any configuration parameter
+    has not been set before, default values are used.
+
+    The environment variable names are in upper case and preceded by 'NX_'
+
+    Parameters
+    ----------
+    settings : NXConfigParser
+        NXConfigParser instance containing NeXpy preferences.
+    """
+
+    def setconfig(parameter):
+        environment_variable = 'NX_'+parameter.upper()
+        if environment_variable in os.environ:
+            value = os.environ[environment_variable]
+        elif settings.has_option('preferences', parameter):
+            value = settings.get('preferences', parameter)
+        else:
+            value = nxgetconfig(parameter)
+        nxsetconfig(**{parameter: value})
+        settings.set('preferences', parameter, nxgetconfig(parameter))
+
+    for parameter in nxgetconfig():
+        setconfig(parameter)
+
     if settings.has_option('preferences', 'style'):
         set_style(settings.get('preferences', 'style'))
     else:
         settings.set('preferences', 'style', 'default')
+
     settings.save()
 
 


### PR DESCRIPTION
* Gives precedence to nexusformat configuration parameters that are defined by environment variables. This allows system administrators to initialize lock directories.
* Adds a `Show File Locks` item to the File menu, which allows locks in a lock directory to be cleared.