### PR TITLE
Add a dependency for importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     ansi2html
     pillow
     mplcursors
+    importlib-metadata; python_version<"3.10"
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This is conditional on the Python version being less than 3.10.