### PR TITLE
Automatically wrap layouts in NXScrollArea

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -1341,10 +1341,7 @@ class DirectoryDialog(NXDialog):
             self.checkbox[f] = NXCheckBox(checked=True)
             grid.addWidget(NXLabel(f), i, 0)
             grid.addWidget(self.checkbox[f], i, 1)
-        scroll_widget = NXWidget()
-        scroll_widget.set_layout(grid)
-        scroll_area = NXScrollArea(scroll_widget)
-        self.set_layout(prefix_layout, scroll_area, self.close_layout())
+        self.set_layout(prefix_layout, NXScrollArea(grid), self.close_layout())
         self.prefix_box.setFocus()
 
     @property
@@ -1597,7 +1594,6 @@ class PlotScalarDialog(NXDialog):
         self.prefix_box = NXLineEdit()
         self.prefix_box.textChanged.connect(self.select_prefix)
         prefix_layout = self.make_layout(NXLabel('Prefix'), self.prefix_box)
-        self.scroll_area = NXScrollArea()
         self.files = GridParameters()
         i = 0
         for name in sorted(self.tree, key=natural_sort):
@@ -1611,9 +1607,7 @@ class PlotScalarDialog(NXDialog):
                     self.files[name].checkbox.stateChanged.connect(
                         self.update_files)
         self.file_grid = self.files.grid(header=('File', self.scan_header, ''))
-        self.scroll_widget = NXWidget()
-        self.scroll_widget.set_layout(self.make_layout(self.file_grid))
-        self.scroll_area.setWidget(self.scroll_widget)
+        self.scroll_area = NXScrollArea(self.make_layout(self.file_grid))
         self.file_box.set_layout(prefix_layout, self.scroll_area,
                                  self.file_box.close_layout())
         self.file_box.close_box.accepted.connect(self.choose_files)
@@ -1635,10 +1629,8 @@ class PlotScalarDialog(NXDialog):
                     self.files[name].checkbox.stateChanged.connect(
                         self.update_files)
         self.file_grid = self.files.grid(header=('File', self.scan_header, ''))
-        self.scroll_widget.deleteLater()
-        self.scroll_widget = NXWidget()
-        self.scroll_widget.set_layout(self.make_layout(self.file_grid))
-        self.scroll_area.setWidget(self.scroll_widget)
+        self.scroll_area.widget().deleteLater()
+        self.scroll_area = NXScrollArea(self.make_layout(self.file_grid))
 
     def update_files(self):
         if self.scan_variable is None:

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -13,7 +13,7 @@ import math
 import warnings
 
 import numpy as np
-from matplotlib import cbook, colors
+from matplotlib import colors
 from matplotlib.patches import Ellipse, Polygon, Rectangle
 
 from .pyqt import QtCore, QtGui, QtWidgets
@@ -100,19 +100,24 @@ class NXSortModel(QtCore.QSortFilterProxyModel):
 class NXScrollArea(QtWidgets.QScrollArea):
     """Scroll area embedding a widget."""
 
-    def __init__(self, widget=None, horizontal=False, parent=None):
+    def __init__(self, content=None, horizontal=False, parent=None):
         """Initialize the scroll area.
 
         Parameters
         ----------
-        widget : QtWidgets.QWidget
-            Widget contained within the scroll area.
+        content : QtWidgets.QWidget or QtWidgets.QLayout
+            Widget or layout to be contained within the scroll area.
         horizontal : bool
             True if a horizontal scroll bar is enabled, default False.
         """
         super().__init__(parent=parent)
-        if widget:
-            self.setWidget(widget)
+        if content:
+            if isinstance(content, QtWidgets.QWidget):
+                self.setWidget(content)
+            elif isinstance(content, QtWidgets.QLayout):
+                widget = QtWidgets.QWidget()
+                widget.setLayout(content)
+                self.setWidget(widget)
         if not horizontal:
             self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.setWidgetResizable(True)
@@ -120,6 +125,10 @@ class NXScrollArea(QtWidgets.QScrollArea):
                            QtWidgets.QSizePolicy.Expanding)
 
     def setWidget(self, widget):
+        if isinstance(widget, QtWidgets.QLayout):
+            w = QtWidgets.QWidget()
+            w.setLayout(widget)
+            widget = w
         super().setWidget(widget)
         widget.setMinimumWidth(widget.sizeHint().width() +
                                self.verticalScrollBar().sizeHint().width())


### PR DESCRIPTION
* Simplifies the coding of scroll areas by allowing both widgets and layouts to be used as scroll area content.