### PR TITLE
Update `nexusformat` dependency.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python >=3.7
-    - nexusformat >=1.0.0
+    - nexusformat >=1.0.2
     - numpy
     - scipy
     - h5py

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ package_dir =
     =src
 python_requires = >=3.7
 install_requires =
-    nexusformat >= 1.0.0
+    nexusformat >= 1.0.2
     numpy
     scipy
     h5py >= 2.9


### PR DESCRIPTION
* `nexusformat` v1.0.2 fixes an incompatibility with IPython 8.12.