### PR TITLE
Revert to Matplotlib resize function

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -226,11 +226,6 @@ class NXFigureManager(FigureManager):
                 self.canvas.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
-    def resize(self, width, height):
-        extra_width = self.window.width() - self.canvas.width()
-        extra_height = self.window.height() - self.canvas.height()
-        self.window.resize(width+extra_width, height+extra_height)
-
     def set_window_title(self, title):
         try:
             self.window.setWindowTitle(title)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -229,7 +229,7 @@ class NXFigureManager(FigureManager):
     def set_window_title(self, title):
         try:
             self.window.setWindowTitle(title)
-        except AttributeError as exception:
+        except AttributeError:
             pass
 
 
@@ -638,7 +638,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.raise_()
         try:
             self.canvas._update_screen(self.screen)
-        except Exception as error:
+        except Exception:
             pass
         self.canvas.activateWindow()
         self.canvas.setFocus()
@@ -1155,7 +1155,7 @@ class NXPlotView(QtWidgets.QDialog):
         p['offset'] = 0.0
         try:
             p['smooth_function'] = interp1d(self.x, self.y, kind='cubic')
-        except Exception as error:
+        except Exception:
             p['smooth_function'] = None
         p['smooth_line'] = None
         p['smooth_linestyle'] = 'None'
@@ -1336,7 +1336,7 @@ class NXPlotView(QtWidgets.QDialog):
                 else:
                     self.image.set_interpolation(self.interpolation)
             self.replot_axes()
-        except Exception as error:
+        except Exception:
             pass
 
     def replot_axes(self, draw=True):
@@ -1897,7 +1897,7 @@ class NXPlotView(QtWidgets.QDialog):
             self._axis_offsets = value
             self.ax.ticklabel_format(useOffset=self._axis_offsets)
             self.draw()
-        except Exception as error:
+        except Exception:
             pass
 
     def set_plot_defaults(self):
@@ -2714,7 +2714,7 @@ class NXPlotView(QtWidgets.QDialog):
             if self.label in self.panels[panel].tabs:
                 try:
                     self.panels[panel].tabs[self.label].update()
-                except Exception as error:
+                except Exception:
                     pass
 
     def remove_panels(self):


### PR DESCRIPTION
* Removes the `resize` function in `NXFigureManager`, which did not correct for the device pixel ratios of high DPI screens. The `resize` function was originally introduced to improve the handling of canvas widths in Qt widgets, but Matplotlib has since committed a new version that handles this correctly.