### PR TITLE
Prevent escape key from closing window

### DIFF
--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -648,6 +648,9 @@ class NXDialog(QtWidgets.QDialog, NXWidget):
                                         QtCore.Qt.NoModifier)
                 QtCore.QCoreApplication.postEvent(widget, event)
                 return True
+            elif key == QtCore.Qt.Key_Escape:
+                event.ignore()
+                return True
         return QtWidgets.QWidget.eventFilter(self, widget, event)
 
     def closeEvent(self, event):


### PR DESCRIPTION
* Fixes an issue when the escape key is pressed when editing a text window (see #412). This can trigger the immediate closure of the window without any chance to save changes. This PR causes event filters to ignore the escape key.