### PR TITLE
Fix CLI interface to accept relative file paths

### DIFF
--- a/src/nexpy/nexpygui.py
+++ b/src/nexpy/nexpygui.py
@@ -7,6 +7,7 @@
 # The full license is in the file COPYING, distributed with this software.
 # -----------------------------------------------------------------------------
 import argparse
+import os
 import sys
 
 import nexpy
@@ -25,6 +26,9 @@ def main():
     parser.add_argument('-f', '--faulthandler', action='store_true',
                         help='enable faulthandler for system crashes')
     args, extra_args = parser.parse_known_args()
+
+    for i, f in enumerate(args.filenames):
+        args.filenames[i] = os.path.abspath(os.path.expanduser(f))
 
     if sys.platform == 'darwin':
         from nexpy.gui.utils import run_pythonw


### PR DESCRIPTION
This PR fixes the issue with loading relative paths with the CLI interface, such as `nexpy test.h5`. Previously, one had to either load the file manually in the GUI after its load or do CLI tricks such as `nexpy $PWD/test.h5`, which is inconvenient.