### PR TITLE
Add-rotation

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -2738,6 +2738,7 @@ class NXPlotView(QtWidgets.QDialog):
             self.replot_data(newaxis=True)
             self.vtab.set_axis(self.vaxis)
         self.update_panels()
+        self.update_tabs()
         self.otab.update()
 
     def update_panels(self):

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -733,6 +733,122 @@ def define_mode():
             plotview.otab.setStyleSheet('color: black')
 
 
+def rotate_point(point, angle=45.0, center=[0.0, 0.0]):
+    """
+    Rotate a point around a given center by a given angle
+
+    Parameters
+    ----------
+    point: 2-element list
+        The point to rotate
+    angle: float
+        The angle of the rotation in degrees
+    center: 2-element list
+        The center of the rotation
+
+    Returns
+    -------
+    2-element list
+        The rotated point
+    """
+    cp = np.subtract(point, center)
+    angle = np.radians(angle)
+    px = cp[0] * np.cos(angle) - cp[1] * np.sin(angle)
+    py = cp[0] * np.sin(angle) + cp[1] * np.cos(angle)
+    return list(np.add([px, py], center))
+
+
+def rotate_data(data, angle=45, aspect='equal'):
+    """
+    Rotate a 2D NXdata object by a specified angle.
+
+    Parameters
+    ----------
+    data : NXdata
+        NXdata object containing the 2D data to be rotated.
+    angle : float, optional
+        Angle of rotation in degrees. Default is 45.
+    aspect : str or float, optional
+        Aspect ratio of the data for rotation calculations. If a float is 
+        provided, it is used to adjust the rotation angle. Default is 'equal'.
+
+    Returns
+    -------
+    NXdata
+        A new NXdata object containing the rotated data and axes.
+
+    Raises
+    ------
+    NeXusError
+        If the input data is not 2D.
+
+    Notes
+    -----
+    The rotation is performed about the geometric center of the data using
+    the scipy.ndimage.rotate function. The axes are recalculated to match 
+    the new dimensions of the rotated data.
+    """
+    if data.ndim != 2:
+        raise NeXusError('Can only rotate 2D data.')
+    elif aspect == 'auto':
+        raise NeXusError('Aspect ratio must be defined.')
+    elif aspect == 'equal':
+        aspect = 1.0
+    original_data = data.nxsignal
+    original_weights = data.nxweights
+    x = data.nxaxes[1]
+    y = data.nxaxes[0]
+    x0 = (x[0] + x[-1])/2
+    y0 = (y[0] + y[-1])/2
+    x_name = f"{x.nxname} * cos({angle}°) - {y.nxname} * sin({angle}°)"
+    y_name = f"{x.nxname} * sin({angle}°) + {y.nxname} * cos({angle}°)"
+
+    corners = [rotate_point((x.min(), y.min()), angle, (x0, y0)),
+               rotate_point((x.max(), y.min()), angle, (x0, y0)),
+               rotate_point((x.max(), y.max()), angle, (x0, y0)),
+               rotate_point((x.min(), y.max()), angle, (x0, y0))]
+    xmin, ymin = np.min(corners, axis=0)
+    xmax, ymax = np.max(corners, axis=0)
+
+    angle = np.radians(angle)
+
+    from scipy.ndimage import rotate, zoom
+
+    if not np.isclose(aspect, 1.0):
+        ny, nx = original_data.shape
+        zoom_y = aspect * (((y.max() - y.min()) * nx) /
+                           ((x.max() - x.min()) * ny))
+        original_data = zoom(original_data, (zoom_y, 1), order=1)
+    else:
+        rotated_aspect = None
+
+    # The angle is negative because scipy assumes a top-left origin
+    angle = - np.degrees(angle)
+
+    rotated_data = NXfield(rotate(original_data, angle, axes=(1,0),
+                                  reshape=True, order=1, mode='constant',
+                                  cval=0.0), name=data.nxsignal.nxname)
+    if np.all(original_data >= 0.0):
+        vmin = np.min(original_data[np.nonzero(original_data)])
+        rotated_data[(rotated_data!=0) & (np.abs(rotated_data)<vmin)] = vmin
+    ny, nx = rotated_data.shape
+    rotated_x = NXfield(np.linspace(xmin, xmax, nx), name='rotated_x',
+                        long_name=x_name)
+    rotated_y = NXfield(np.linspace(ymin, ymax, ny), name='rotated_y',
+                        long_name=y_name)
+    rotated_aspect = ((xmax - xmin) * ny) / ((ymax - ymin) * nx)
+    if original_weights is not None:
+        rotated_weights = NXfield(rotate(original_weights, angle, axes=(1,0),
+                                         reshape=True, order=1,
+                                         mode='constant', cval=0.0),
+                                  name=data.nxweights.nxname)
+    result = NXdata(rotated_data, (rotated_y, rotated_x), title=data.nxtitle)
+    result.attrs['aspect'] = rotated_aspect
+    if original_weights is not None:
+        result.nxweights = rotated_weights
+    return result
+
+
 class NXListener(QtCore.QObject):
 
     change_signal = QtCore.Signal(str)

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -1381,16 +1381,18 @@ class NXpolygon(NXpatch):
 
 class NXline:
 
-    def __init__(self, plotview=None):
+    def __init__(self, plotview=None, callback=None):
         if plotview:
             self.plotview = plotview
         else:
             from .plotview import get_plotview
             self.plotview = get_plotview()
+        self.callback = callback
         self.ax = self.plotview.ax
         self.canvas = self.plotview.canvas
         self.line = None
         self.start_point = None
+        self.connect()
 
     def connect(self):
         self.cidpress = self.canvas.mpl_connect('button_press_event',
@@ -1412,7 +1414,7 @@ class NXline:
         if event.inaxes != self.ax:
             return
         self.start_point = (event.xdata, event.ydata)
-        self.line, = self.ax.plot([event.xdata], [event.ydata], ':r', lw=4)
+        self.line, = self.ax.plot([event.xdata], [event.ydata], ':w', lw=4)
 
     def on_move(self, event):
         if self.start_point is None or event.inaxes != self.ax:
@@ -1425,6 +1427,8 @@ class NXline:
         if event.inaxes != self.ax:
             return
         self.end_point = (event.xdata, event.ydata)
-        self.plotview.ptab.read_rotation_angle()
+        if self.callback:
+            self.callback(self.start_point, self.end_point)
+        self.disconnect()
         self.line.remove()
         self.canvas.draw()

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -998,7 +998,7 @@ class NXpatch:
         return getattr(self.shape, name)
 
     def connect(self):
-        'connect to all the events we need'
+        """Connect this patch to the plotting window canvas events."""
         self.plotview.deactivate()
         self.cidpress = self.canvas.mpl_connect(
             'button_press_event', self.on_press)
@@ -1008,6 +1008,7 @@ class NXpatch:
             'motion_notify_event', self.on_motion)
 
     def is_inside(self, event):
+        """Check if the event is inside the shape."""
         if event.inaxes != self.shape.axes:
             return False
         contains, _ = self.shape.contains(event)
@@ -1376,3 +1377,54 @@ class NXpolygon(NXpatch):
         xy0, xp, yp = self.press
         dxy = (x-xp, y-yp)
         self.polygon.set_xy(xy0+dxy)
+
+
+class NXline:
+
+    def __init__(self, plotview=None):
+        if plotview:
+            self.plotview = plotview
+        else:
+            from .plotview import get_plotview
+            self.plotview = get_plotview()
+        self.ax = self.plotview.ax
+        self.canvas = self.plotview.canvas
+        self.line = None
+        self.start_point = None
+
+    def connect(self):
+        self.cidpress = self.canvas.mpl_connect('button_press_event',
+                                                self.on_press)
+        self.cidrelease = self.canvas.mpl_connect('button_release_event',
+                                                  self.on_release)
+        self.cidmotion = self.canvas.mpl_connect('motion_notify_event',
+                                                 self.on_move)
+        self.plotview.deactivate()
+
+    def disconnect(self):
+        """Disconnect all the stored connection ids."""
+        self.canvas.mpl_disconnect(self.cidpress)
+        self.canvas.mpl_disconnect(self.cidrelease)
+        self.canvas.mpl_disconnect(self.cidmotion)
+        self.plotview.activate()
+
+    def on_press(self, event):
+        if event.inaxes != self.ax:
+            return
+        self.start_point = (event.xdata, event.ydata)
+        self.line, = self.ax.plot([event.xdata], [event.ydata], ':r', lw=4)
+
+    def on_move(self, event):
+        if self.start_point is None or event.inaxes != self.ax:
+            return
+        self.line.set_data([self.start_point[0], event.xdata],
+                           [self.start_point[1], event.ydata])
+        self.canvas.draw()
+
+    def on_release(self, event):
+        if event.inaxes != self.ax:
+            return
+        self.end_point = (event.xdata, event.ydata)
+        self.plotview.ptab.read_rotation_angle()
+        self.line.remove()
+        self.canvas.draw()


### PR DESCRIPTION
* Adds an option to rotate the currently plotted data by a specifed angle.
* Redesigns the Projection tab to define the rotation angle and allow the aspect ratio and skew angle to be set.
* Allows a 1D plot of any line through a 2D plot drawn interactively with the Shift key depressed.