### PR TITLE
Make entry points compatible with Python 3.9

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -231,10 +231,11 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
                     plugin  = str(path)
                     if plugin not in plugins:
                         self.settings.set(plugin_group, plugin, value=None)
-            for entry in entry_points(group='nexpy.'+plugin_group):
-                plugin = entry.module
-                if plugin not in plugins:
-                    self.settings.set(plugin_group, plugin, value=None)
+            if 'nexpy.' + plugin_group in entry_points():
+                for entry in entry_points()['nexpy.'+plugin_group]:
+                    plugin = entry.module
+                    if plugin not in plugins:
+                        self.settings.set(plugin_group, plugin, value=None)
         initialize_plugin('plugins', self.plugin_dir)
         initialize_plugin('readers', self.reader_dir)
         initialize_plugin('writers', self.writer_dir)

--- a/src/nexpy/gui/datadialogs.py
+++ b/src/nexpy/gui/datadialogs.py
@@ -4712,7 +4712,10 @@ class ManagePluginsDialog(NXDialog):
         self.settings = self.mainwindow.settings
         for plugin in [p for p in self.settings.options('plugins')
                        if p not in self.plugins]:
-            self.plugins[plugin] = load_plugin(plugin)
+            try:
+                self.plugins[plugin] = load_plugin(plugin)
+            except Exception as error:
+                report_error("Managing plugins", error)
 
         self.grid = QtWidgets.QGridLayout()
         self.grid.setSpacing(10)


### PR DESCRIPTION
* Fixes incompatibility in the `entry_points` keyword arguments with Python 3.9
* Improves error handling when a plugin is declared but not installed