### PR TITLE
Fix-rotation-lines

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -4351,8 +4351,12 @@ class NXProjectionTab(QtWidgets.QWidget):
         else:
             plotview = NXPlotView(label)
             plotview.plot(rotated_line)
-            plotviews[label].xtab.minbox.setValue(rotated_xmin)
-            plotviews[label].xtab.maxbox.setValue(rotated_xmax)
+        plotviews[label].xtab.minbox.setValue(rotated_xmin)
+        plotviews[label].xtab.maxbox.setValue(rotated_xmax)
+        idx = len(plotviews[label].plots)
+        legend_label = f"{rotation_angle:.0f}° y = {rotated_y:.2f}"
+        plotviews[label].plots[idx]['legend_label'] = legend_label
+        plotviews[label].legend()
 
 
 class NXNavigationToolbar(NavigationToolbar2QT, QtWidgets.QToolBar):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -4330,7 +4330,7 @@ class NXProjectionTab(QtWidgets.QWidget):
             elif np.abs(np.abs(rotation_angle) - 90.0) < 5.0:
                 rotation_angle = 90.0
             else:
-                rotation_angle = np.round(rotation_angle)
+                rotation_angle = np.round(rotation_angle / 5.0) * 5.0
         except ZeroDivisionError:
             rotation_angle = 90.0
         rotation_angle = -rotation_angle

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -1004,7 +1004,14 @@ def rotate_data(data, angle=45, aspect='equal'):
     elif aspect == 'equal':
         aspect = 1.0
 
+    x = data.nxaxes[1]
+    y = data.nxaxes[0]
+    x0 = (x[0] + x[-1])/2
+    y0 = (y[0] + y[-1])/2
+
     if np.isclose(angle, 0.0):
+        data.attrs['x0'] = x0
+        data.attrs['y0'] = y0
         return data
     elif np.isclose(np.abs(angle), 90.0):
         signal = NXfield(np.swapaxes(data.nxsignal, 0, 1), name=data.nxsignal,
@@ -1024,15 +1031,13 @@ def rotate_data(data, angle=45, aspect='equal'):
         y = data.nxaxes[0]
         x = data.nxaxes[1]
         result = NXdata(signal, (x, y), errors=errors, weights=weights)
+        result.attrs['x0'] = x0
+        result.attrs['y0'] = y0
         return result
 
     original_data = data.nxsignal
     original_errors = data.nxerrors
     original_weights = data.nxweights
-    x = data.nxaxes[1]
-    y = data.nxaxes[0]
-    x0 = (x[0] + x[-1])/2
-    y0 = (y[0] + y[-1])/2
     x_name = f"{x.nxname} * cos({angle}°) - {y.nxname} * sin({angle}°)"
     y_name = f"{x.nxname} * sin({angle}°) + {y.nxname} * cos({angle}°)"
 
@@ -1082,6 +1087,8 @@ def rotate_data(data, angle=45, aspect='equal'):
                                   name=data.nxweights.nxname)
     result = NXdata(rotated_data, (rotated_y, rotated_x), title=data.nxtitle)
     result.attrs['aspect'] = rotated_aspect
+    result.attrs['x0'] = x0
+    result.attrs['y0'] = y0
     if original_errors is not None:
         result.nxerrors = rotated_errors
     if original_weights is not None:


### PR DESCRIPTION
* Fixes a bug in selecting the rotated y-value when the center of the 2D plot is not at (0,0).
* Restricts the selected angle to multiples of 5°.
* Display a legend with labels for each rotated line.