### PR TITLE
Fix PyQt6 issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "lmfit",
     "matplotlib",
     "mplcursors",
-    "nexusformat >= 2.0.0b3",
+    "nexusformat >= 2.0.0b4",
     "numpy",
     "packaging",
     "pillow",

--- a/src/nexpy/gui/dialogs.py
+++ b/src/nexpy/gui/dialogs.py
@@ -458,7 +458,6 @@ class PlotScalarDialog(NXDialog):
             The parent window of the dialog, by default None
         """
         super().__init__(parent=parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
 
         if isinstance(node, NXfield):
             self.node = node

--- a/src/nexpy/gui/dialogs.py
+++ b/src/nexpy/gui/dialogs.py
@@ -162,7 +162,7 @@ class DirectoryDialog(NXDialog):
 
 class PlotDialog(NXDialog):
 
-    def __init__(self, node, parent=None, lines=False):
+    def __init__(self, node, lines=False, parent=None):
 
         """
         Initialize the dialog to plot arbitrary NeXus data in 1D or 2D.

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2648,20 +2648,6 @@ class MainWindow(QtWidgets.QMainWindow):
             except Exception:
                 pass
 
-    def close_widgets(self):
-        """
-        Close all open dialog windows, including plot windows
-        other than the main window.
-        """
-        windows = self.dialogs
-        windows += [self.plotviews[pv]
-                    for pv in self.plotviews if pv != 'Main']
-        for window in windows:
-            try:
-                window.close()
-            except Exception:
-                pass
-
     def closeEvent(self, event):
         """Customize the close event to confirm request to quit."""
         if confirm_action("Are you sure you want to quit NeXpy?",
@@ -2669,7 +2655,6 @@ class MainWindow(QtWidgets.QMainWindow):
             self.console.kernel_client.stop_channels()
             self.console.kernel_manager.shutdown_kernel()
             self.close_files()
-            self.close_widgets()
             logging.info('NeXpy closed\n'+80*'-')
             self._app.quit()
             return event.accept()

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2013-2021, NeXpy Development Team.
+# Copyright (c) 2013-2025, NeXpy Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,8 +8,9 @@
 
 """The Qt MainWindow for NeXpy
 
-This is an expanded version on the Jupyter QtConsole with the addition
-of a Matplotlib plotting pane and a tree view for displaying NeXus data.
+This contains a tree view to display NeXus data, a Matplotlib canvas to
+plot the data, and a Jupyter console to execute Python commands. The
+namespace of the console includes the NeXus data loaded into the tree.
 """
 
 # -----------------------------------------------------------------------------
@@ -95,12 +96,18 @@ class MainWindow(QtWidgets.QMainWindow):
 
         super().__init__()
         self.resize(1000, 800)
+
         self.app = app
         self._app = app.app
         self._app.setStyle("QMacStyle")
         self.settings = settings
         self.config = config
+
+        self.dialogs = []
+        self.panels = {}
+        self.log_window = None
         self.copied_node = None
+        self._memroot = None
 
         self.default_directory = Path.home()
         self.nexpy_dir = self.app.nexpy_dir
@@ -114,20 +121,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
         mainwindow = QtWidgets.QWidget()
 
-        rightpane = QtWidgets.QWidget()
+        self.mainview = NXPlotView(label="Main", mainwindow=self)
 
-        self.dialogs = []
-        self.panels = {}
-        self.log_window = None
-        self._memroot = None
-
-        main_plotview = NXPlotView(label="Main", parent=self)
-
-        self.console = NXRichJupyterWidget(config=self.config,
-                                           parent=rightpane)
+        self.console = NXRichJupyterWidget(config=self.config)
         self.console.setMinimumSize(750, 100)
-        self.console.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
-                                   QtWidgets.QSizePolicy.Fixed)
         self.console._confirm_exit = True
         self.console.kernel_manager = QtInProcessKernelManager(
             config=self.config)
@@ -157,27 +154,22 @@ class MainWindow(QtWidgets.QMainWindow):
             self.shell._last_traceback = stb
         self.shell._showtraceback = new_stb
 
+        self.tree = tree
+        self.treeview = NXTreeView(self.tree, mainwindow=self)
+        self.treeview.setMinimumWidth(200)
+        self.treeview.setMaximumWidth(400)
+
+        rightpane = QtWidgets.QWidget()
+
         right_splitter = QtWidgets.QSplitter(rightpane)
         right_splitter.setOrientation(QtCore.Qt.Vertical)
-        right_splitter.addWidget(main_plotview)
+        right_splitter.addWidget(self.mainview)
         right_splitter.addWidget(self.console)
 
         rightlayout = QtWidgets.QVBoxLayout()
         rightlayout.addWidget(right_splitter)
         rightlayout.setContentsMargins(0, 0, 0, 0)
         rightpane.setLayout(rightlayout)
-
-        self.tree = tree
-        self.treeview = NXTreeView(self.tree, parent=self)
-        self.treeview.setMinimumWidth(200)
-        self.treeview.setMaximumWidth(400)
-        self.treeview.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                    QtWidgets.QSizePolicy.Expanding)
-        self.user_ns['plotview'] = self.plotview
-        self.user_ns['plotviews'] = self.plotviews = self.plotview.plotviews
-        self.user_ns['treeview'] = self.treeview
-        self.user_ns['nxtree'] = self.user_ns['_tree'] = self.tree
-        self.user_ns['mainwindow'] = self
 
         left_splitter = QtWidgets.QSplitter(mainwindow)
         left_splitter.setOrientation(QtCore.Qt.Horizontal)
@@ -190,6 +182,12 @@ class MainWindow(QtWidgets.QMainWindow):
         mainwindow.setLayout(mainlayout)
 
         self.setCentralWidget(mainwindow)
+
+        self.user_ns['plotview'] = self.plotview
+        self.user_ns['plotviews'] = self.plotviews = self.plotview.plotviews
+        self.user_ns['treeview'] = self.treeview
+        self.user_ns['nxtree'] = self.user_ns['_tree'] = self.tree
+        self.user_ns['mainwindow'] = self
 
         self.nxclasses = get_base_classes()
 
@@ -2140,7 +2138,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def new_plot_window(self):
         """Create a new plot window"""
-        return NXPlotView(parent=self)
+        return NXPlotView()
 
     def close_window(self):
         """

--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -1517,7 +1517,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     except (KeyError, NeXusError):
                         pass
                 elif node.is_plottable():
-                    dialog = PlotDialog(node, parent=self, lines=True)
+                    dialog = PlotDialog(node, lines=True, parent=self)
                     dialog.show()
                 else:
                     raise NeXusError("Data not plottable")

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -664,8 +664,8 @@ class NXPlotView(QtWidgets.QDialog):
             self.canvas._update_screen(self.screen)
         except Exception:
             pass
-        self.canvas.activateWindow()
-        self.canvas.setFocus()
+        self.activateWindow()
+        self.setFocus()
         self.update_active()
 
     def update_active(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -1462,6 +1462,8 @@ class NXPlotView(QtWidgets.QDialog):
         """
         if self.colorbar:
             if Version(mpl.__version__) >= Version('3.1.0'):
+                self.set_data_norm()
+                self.image.set_norm(self.norm)
                 self.colorbar.update_normal(self.image)
             else:
                 self.colorbar.set_norm(self.norm)
@@ -4603,6 +4605,10 @@ class NXNavigationToolbar(NavigationToolbar2QT, QtWidgets.QToolBar):
         self.plotview.ytab.set_sliders(ymin, ymax)
         self.plotview.ytab.block_signals(False)
         if self.plotview.image:
+            if isinstance(self.plotview.image.norm, LogNorm):
+                self.plotview.vtab.log = True
+            else:
+                self.plotview.vtab.log = False
             self.plotview.update_colorbar()
         self.plotview.update_panels()
 

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -192,13 +192,6 @@ def get_plotview():
 class NXCanvas(FigureCanvas):
     """Subclass of Matplotlib's FigureCanvas."""
 
-    def __init__(self, figure):
-
-        FigureCanvas.__init__(self, figure)
-
-        self.setSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding,
-                           QtWidgets.QSizePolicy.MinimumExpanding)
-
     def get_default_filename(self):
         """Return a string suitable for use as a default filename."""
         basename = (self.manager.get_window_title().replace('NeXpy: ', '')

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -381,7 +381,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.ytab = NXPlotTab('y', plotview=self)
         self.ztab = NXPlotTab('z', zaxis=True, plotview=self)
         self.ptab = NXProjectionTab(plotview=self)
-        self.otab = NXNavigationToolbar(self.canvas, self.tab_widget)
+        self.otab = NXNavigationToolbar(self.canvas)
         self.figuremanager.toolbar = self.otab
         self.tab_widget.addTab(self.xtab, 'x')
         self.tab_widget.addTab(self.ytab, 'y')
@@ -3985,7 +3985,7 @@ class NXPlotTab(QtWidgets.QWidget):
         _pause_icon = resource_icon('pause-icon.png')
         _forward_icon = resource_icon('forward-icon.png')
         _refresh_icon = resource_icon('refresh-icon.png')
-        self.toolbar = QtWidgets.QToolBar(parent=self)
+        self.toolbar = QtWidgets.QToolBar()
         self.toolbar.setIconSize(QtCore.QSize(16, 16))
         self.add_action(_refresh_icon, self.plotview.replot_data, "Replot",
                         checkable=False)
@@ -4377,7 +4377,7 @@ class NXNavigationToolbar(NavigationToolbar2QT, QtWidgets.QToolBar):
         ('Add', 'Add plot data to tree', 'hand', 'add_data')
     )
 
-    def __init__(self, canvas, parent=None, coordinates=True):
+    def __init__(self, canvas, coordinates=True):
         """
         Initialize the navigation toolbar.
 
@@ -4391,11 +4391,11 @@ class NXNavigationToolbar(NavigationToolbar2QT, QtWidgets.QToolBar):
             Whether to display the coordinates of the mouse position, by
             default True
         """
-        QtWidgets.QToolBar.__init__(self, parent=parent)
+        QtWidgets.QToolBar.__init__(self)
         self.setAllowedAreas(QtCore.Qt.BottomToolBarArea)
 
         self.coordinates = coordinates
-        self._actions = {}  # mapping of toolitem method names to QActions.
+        self._actions = {}
         self._subplot_dialog = None
 
         for text, tooltip_text, image_file, callback in self.toolitems:

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -3008,7 +3008,6 @@ class NXPlotView(QtWidgets.QDialog):
     def closeEvent(self, event):
         """Close this widget and mark it for deletion."""
         self.close_view()
-        self.deleteLater()
         event.accept()
 
     def close(self):

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -327,12 +327,14 @@ class NXPlotView(QtWidgets.QDialog):
             The parent window of the dialog, by default None
         """
 
-        super().__init__(parent=parent)
 
         if mainwindow:
             self.mainwindow = mainwindow
         else:
             self.mainwindow = get_mainwindow()
+            parent = self.mainwindow
+
+        super().__init__(parent=parent)
 
         self.setMinimumSize(750, 550)
         self.setFocusPolicy(QtCore.Qt.ClickFocus)

--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -62,10 +62,10 @@ from nexusformat.nexus import NeXusError, NXdata, NXfield
 from .dialogs import (CustomizeDialog, ExportDialog, LimitDialog,
                       ProjectionDialog, ScanDialog, StyleDialog)
 from .utils import (boundaries, centers, display_message, divgray_map,
-                    find_nearest, fix_projection, get_color, in_dark_mode,
-                    iterable, keep_data, load_image, parula_map, report_error,
-                    report_exception, resource_file, resource_icon,
-                    rotate_data, rotate_point, xtec_map)
+                    find_nearest, fix_projection, get_color, get_mainwindow,
+                    in_dark_mode, iterable, keep_data, load_image, parula_map,
+                    report_error, report_exception, resource_file,
+                    resource_icon, rotate_data, rotate_point, xtec_map)
 from .widgets import (NXCheckBox, NXcircle, NXComboBox, NXDoubleSpinBox,
                       NXellipse, NXLabel, NXline, NXLineEdit, NXpolygon,
                       NXPushButton, NXrectangle, NXSlider, NXSpinBox,
@@ -316,7 +316,7 @@ class NXPlotView(QtWidgets.QDialog):
         y-axis, and 2 for the x-axis.
     """
 
-    def __init__(self, label=None, parent=None):
+    def __init__(self, label=None, mainwindow=None, parent=None):
 
         """
         Initialize the NXPlotView window.
@@ -328,21 +328,20 @@ class NXPlotView(QtWidgets.QDialog):
             used as the key to select an instance in the 'dialogs' dictionary.
             If a label is not given, the window will be labeled as
             "Figure 1", "Figure 2", etc.
+        mainwindow : QMainWindow, optional
+            The main window of the application, by default None
         parent : QWidget, optional
             The parent window of the dialog, by default None
         """
-        if parent is not None:
-            self.mainwindow = parent
-        else:
-            from .consoleapp import _mainwindow
-            self.mainwindow = _mainwindow
-            parent = self.mainwindow
 
-        super().__init__(parent)
+        super().__init__(parent=parent)
+
+        if mainwindow:
+            self.mainwindow = mainwindow
+        else:
+            self.mainwindow = get_mainwindow()
 
         self.setMinimumSize(750, 550)
-        self.setSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding,
-                           QtWidgets.QSizePolicy.MinimumExpanding)
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         if label in plotviews:

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -427,7 +427,7 @@ class NXTreeItem(QtGui.QStandardItem):
 
 class NXTreeView(QtWidgets.QTreeView):
 
-    def __init__(self, tree, parent=None):
+    def __init__(self, tree, mainwindow):
         """
         Initialize a NeXus tree view.
 
@@ -435,13 +435,15 @@ class NXTreeView(QtWidgets.QTreeView):
         ----------
         tree : NXtree
             The root of the tree.
+        mainwindow : NXMainWindow
+            The main window of the application.
         parent : QWidget, optional
             The parent of the view.
         """
-        super().__init__(parent=parent)
+        super().__init__()
 
         self.tree = tree
-        self.mainwindow = parent
+        self.mainwindow = mainwindow
         self._model = QtGui.QStandardItemModel()
         self.proxymodel = NXSortModel(self)
         self.proxymodel.setSourceModel(self._model)

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -94,7 +94,9 @@ class NXtree(NXgroup):
             for row in range(self._item.rowCount()):
                 for item in self._item.child(row).walk():
                     self.sync_children(item)
-            self._view.dataChanged(self._item.index(), self._item.index())
+            index = self._item.index()
+            if index.isValid():
+                self._view.dataChanged(index, index)
             self._view.update()
             self._view.status_message(self._view.node)
 

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -165,6 +165,12 @@ def run_pythonw(script_path):
             warnings.warn(msg)
 
 
+def get_mainwindow():
+    """Return the NeXpy main window"""
+    from .consoleapp import _mainwindow
+    return _mainwindow
+
+
 def is_file_locked(filename, wait=5, expiry=None):
     """
     Check if a file is locked.
@@ -891,8 +897,8 @@ def in_dark_mode():
         True if the application is in dark mode, False otherwise.
     """
     try:
-        from .consoleapp import _mainwindow
-        app = _mainwindow.app.app
+        mainwindow = get_mainwindow()
+        app = mainwindow.app.app
         return (app.palette().window().color().value() <
                 app.palette().windowText().color().value())
     except Exception:
@@ -910,22 +916,22 @@ def define_mode():
     This function is typically called when the application is first
     launched or when the user changes the display mode from the menu.
     """
-    from .consoleapp import _mainwindow
+    mainwindow = get_mainwindow()
     if in_dark_mode():
-        _mainwindow.console.set_default_style('linux')
-        _mainwindow.statusBar().setPalette(_mainwindow.app.app.palette())
+        mainwindow.console.set_default_style('linux')
+        mainwindow.statusBar().setPalette(mainwindow.app.app.palette())
     else:
-        _mainwindow.console.set_default_style()
-        _mainwindow.statusBar().setPalette(_mainwindow.app.app.palette())
+        mainwindow.console.set_default_style()
+        mainwindow.statusBar().setPalette(mainwindow.app.app.palette())
 
-    for dialog in _mainwindow.dialogs:
+    for dialog in mainwindow.dialogs:
         if dialog.windowTitle() == 'Script Editor':
             for tab in [dialog.tabs[t] for t in dialog.tabs]:
                 tab.define_style()
         elif dialog.windowTitle().startswith('Log File'):
             dialog.format_log()
 
-    for plotview in _mainwindow.plotviews.values():
+    for plotview in mainwindow.plotviews.values():
         if in_dark_mode():
             plotview.otab.setStyleSheet('color: white')
         else:

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -19,7 +19,8 @@ from nexusformat.nexus import NeXusError, NXfield, NXroot
 
 from .pyqt import QtCore, QtGui, QtWidgets, getOpenFileName
 from .utils import (boundaries, confirm_action, display_message, find_nearest,
-                    format_float, get_color, natural_sort, report_error)
+                    format_float, get_color, get_mainwindow, natural_sort,
+                    report_error)
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -1136,8 +1137,7 @@ class NXDialog(QtWidgets.QDialog, NXWidget):
         -----
         If parent is None, the parent will be set to the main window.
         """
-        from .consoleapp import _mainwindow
-        self.mainwindow = _mainwindow
+        self.mainwindow = get_mainwindow()
         if parent is None:
             parent = self.mainwindow
         QtWidgets.QDialog.__init__(self, parent=parent)

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -1142,7 +1142,7 @@ class NXDialog(QtWidgets.QDialog, NXWidget):
             parent = self.mainwindow
         QtWidgets.QDialog.__init__(self, parent=parent)
         self.set_attributes()
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self.setSizeGripEnabled(True)
         self.mainwindow.dialogs.append(self)
         if not default:


### PR DESCRIPTION
* Ensures that the widgets embedded in the main window have their respective QSplitter panes as parent. PyQt6 will not collapse widgets with incorrect parents.
* Ensures that all other plot and dialog windows have the parent set to the main window, and are not closed programmatically by NeXpy when quitting. Segmentation faults when quitting the PyQt6 version sometimes occur because of double deletion attempts. By ensuring strict parentage, both the PyQt5 and PyQt6 versions appear to quit without problems. 
* Fixes a bug when an incorrect tree view index is triggered (again in PyQt6).
* Fixes a bug when the plot window history reaches its limits.
* Fixes a bug when the signal colorbar is toggled between log and linear scales when cycling through the history.