### PR TITLE
Add directory for public scripts

### DIFF
--- a/src/nexpy/gui/dialogs.py
+++ b/src/nexpy/gui/dialogs.py
@@ -1116,6 +1116,10 @@ class SettingsDialog(NXDialog):
         self.parameters.add('lockexpiry', cfg['lockexpiry'], 'Lock Expiry (s)')
         self.parameters.add('lockdirectory', cfg['lockdirectory'],
                             'Lock Directory')
+        self.parameters.add('scriptdirectory',
+                            self.mainwindow.settings.get('settings',
+                                                         'scriptdirectory'),
+                            'Script Directory')
         self.parameters.add('definitions', cfg['definitions'],
                             'NeXus Definitions Directory')
         self.parameters.add('recursive', ['True', 'False'], 'File Recursion')
@@ -1154,6 +1158,8 @@ class SettingsDialog(NXDialog):
                                      cfg['lockexpiry'])
         self.mainwindow.settings.set('settings', 'lockdirectory',
                                      cfg['lockdirectory'])
+        self.mainwindow.settings.set('settings', 'scriptdirectory',
+                                     self.parameters['scriptdirectory'].value)
         self.mainwindow.settings.set('settings', 'definitions',
                                      cfg['definitions'])
         self.mainwindow.settings.set('settings', 'recursive',

--- a/src/nexpy/gui/scripteditor.py
+++ b/src/nexpy/gui/scripteditor.py
@@ -395,5 +395,5 @@ class NXScriptEditor(NXTab):
                     f"Are you sure you want to delete '{self.file_name}'?",
                     "This cannot be reversed"):
                 Path(self.file_name).unlink()
-                self.mainwindow.remove_script_action(self.file_name)
+                self.mainwindow.refresh_script_menus()
                 self.panel.close()

--- a/src/nexpy/gui/scripteditor.py
+++ b/src/nexpy/gui/scripteditor.py
@@ -192,13 +192,16 @@ class NXScriptWindow(NXPanel):
         """
         if file_name:
             label = Path(file_name).name
+            tooltip = file_name
         else:
             label = f'Untitled {self.count+1}'
+            tooltip = label
         super().activate(label, file_name)
         if file_name:
             self.tab.default_directory = Path(file_name).parent
         else:
             self.tab.default_directory = self.mainwindow.script_dir
+        self.tabwidget.setTabToolTip(self.tab.index, tooltip)
 
 
 class NXScriptEditor(NXTab):
@@ -361,8 +364,8 @@ class NXScriptEditor(NXTab):
                 f.write(self.get_text())
             self.file_name = file_name
             self.tab_label = Path(self.file_name).name
-            self.mainwindow.add_script_action(self.file_name,
-                                              self.mainwindow.script_menu)
+            self.panel.tabwidget.setTabToolTip(self.index, file_name)
+            self.mainwindow.refresh_script_menus()
             self.delete_button.setVisible(True)
 
     def reload_script(self):

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -889,6 +889,12 @@ def initialize_settings(settings):
     else:
         settings.set('settings', 'style', 'default')
 
+    script_directory = os.environ.get('NX_SCRIPTDIRECTORY', '')
+    if script_directory and Path(script_directory).is_dir():
+        settings.set('settings', 'scriptdirectory', script_directory)
+    elif not settings.has_option('settings', 'scriptdirectory'):
+        settings.set('settings', 'scriptdirectory', None)
+
     if 'plugins' not in settings.sections():
         settings.add_section('plugins')
 


### PR DESCRIPTION
* Adds a setting to define the path to a public script directory. This setting is initialized by the NX_SCRIPTDIRECTORY environment variable.
* Splits the script menu into public and private directory paths.
* Adds a tooltip to the script window tab to output the script file path.