### PR TITLE
Fix an issue with Fit Panel checkboxes in PyQt6.

### DIFF
--- a/src/nexpy/gui/consoleapp.py
+++ b/src/nexpy/gui/consoleapp.py
@@ -195,10 +195,7 @@ class NXConsoleApp(JupyterQtConsoleApp):
         self.app.setApplicationName('nexpy')
         sys.excepthook = report_exception
         try:
-            if 'svg' in QtGui.QImageReader.supportedImageFormats():
-                self.app.icon = resource_icon('NeXpy.svg')
-            else:
-                self.app.icon = resource_icon('NeXpy.png')
+            self.app.icon = resource_icon('NeXpy.png')
             QtWidgets.QApplication.setWindowIcon(self.app.icon)
             self.icon_pixmap = QtGui.QPixmap(
                 self.app.icon.pixmap(QtCore.QSize(64, 64)))

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -1348,7 +1348,7 @@ class FitTab(NXTab):
                 p.value = make_float(p.box['value'].text())
                 p.min = make_float(p.box['min'].text())
                 p.max = make_float(p.box['max'].text())
-                p.vary = not p.box['fixed'].checkState()
+                p.vary = not p.box['fixed'].isChecked()
         for m in self.models:
             for parameter in m['parameters']:
                 p = m['parameters'][parameter]


### PR DESCRIPTION
* Uses the 'is_checked' function to determine the checkbox state. In PyQt6, the checkState function returns an Enum value, which returns False following 'not', whether the box is checked or not.