### PR TITLE
Allow fit parameters to be copied

### DIFF
--- a/src/nexpy/gui/dialogs.py
+++ b/src/nexpy/gui/dialogs.py
@@ -4551,7 +4551,8 @@ class EditTab(NXTab):
         if not isinstance(self.group, NXgroup):
             raise NeXusError('The node must be a NeXus group')
 
-        field_list = [f for f in self.group.NXfield if f.ndim == 0]
+        field_list = [f for f in self.group.NXfield
+                      if f.ndim == 0 or (f.ndim == 1 and f.shape[0] == 1)]
         if len(field_list) == 0:
             raise NeXusError(f"No scalar fields found in {self.group.nxpath}")
 
@@ -4567,21 +4568,24 @@ class EditTab(NXTab):
             column += 1
 
         row = 1
+        grid_height = 0
         for field in field_list:
             self.grid.addWidget(NXLabel(field.nxname), row, 0,
                                 QtCore.Qt.AlignTop)
             if field.is_string():
-                self.grid.addWidget(NXTextEdit(field.nxvalue, autosize=True),
-                                    row, 1, QtCore.Qt.AlignTop)
+                field_box = NXTextEdit(field.nxvalue, autosize=True)
+                grid_height += field_box.document().size().height()
+                self.grid.addWidget(field_box, row, 1, QtCore.Qt.AlignTop)
             else:
-                self.grid.addWidget(NXTextEdit(field.nxvalue, align='right',
-                                               autosize=True),
-                                    row, 1)
+                field_box = NXTextEdit(field.nxvalue, align='right',
+                                       autosize=True)
+                grid_height += field_box.document().size().height()
+                self.grid.addWidget(field_box, row, 1)
                 self.grid.addWidget(NXLabel(field.nxunits), row, 2)
             row += 1
         self.grid.setContentsMargins(10, 10, 40, 10)
         self.grid.setSpacing(5)
-        if len(field_list) > 10:
+        if grid_height > 800:
             self.scroll_area = NXScrollArea(self.grid, height=800)
             self.scroll_area.setMinimumHeight(200)
             self.set_layout(self.scroll_area)

--- a/src/nexpy/gui/fitdialogs.py
+++ b/src/nexpy/gui/fitdialogs.py
@@ -298,13 +298,13 @@ class FitTab(NXTab):
         self.remove_combo = NXComboBox()
         self.restore_button = NXPushButton("Restore Parameters",
                                            self.restore_parameters)
-        self.save_parameters_button = NXPushButton("Copy Parameters",
+        self.copy_parameters_button = NXPushButton("Copy Parameters",
                                                    self.copy_parameters)
         self.remove_layout = self.make_layout(self.remove_button,
                                               self.remove_combo,
                                               'stretch',
                                               self.restore_button,
-                                              self.save_parameters_button,
+                                              self.copy_parameters_button,
                                               align='justified')
 
         if self.plotview is None:
@@ -508,7 +508,7 @@ class FitTab(NXTab):
             self.remove_button.setVisible(False)
             self.remove_combo.setVisible(False)
             self.restore_button.setVisible(False)
-            self.save_parameters_button.setVisible(False)
+            self.copy_parameters_button.setVisible(False)
             self.fit_button.setVisible(False)
             self.fit_combo.setVisible(False)
             self.fit_checkbox.setVisible(False)
@@ -525,7 +525,7 @@ class FitTab(NXTab):
                 self.compose_button.setVisible(True)
             self.remove_button.setVisible(True)
             self.remove_combo.setVisible(True)
-            self.save_parameters_button.setVisible(True)
+            self.copy_parameters_button.setVisible(True)
             self.fit_button.setVisible(True)
             self.fit_combo.setVisible(True)
             self.fit_checkbox.setVisible(True)
@@ -887,7 +887,7 @@ class FitTab(NXTab):
             else:
                 self.model = self.eval_model(self.composite_model)
             self.write_parameters()
-            self.save_parameters_button.setVisible(True)
+            self.copy_parameters_button.setVisible(True)
             self.save_fit_button.setVisible(False)
 
     def convert_parameter_name(self, parameter, saved_parameters):


### PR DESCRIPTION
* Adds a "Copy Fit" button to the Fit Tab to allow the fit results to be copied to a NXprocess group for pasting into another group in the tree.
* Improves the estimated height of Edit Tabs to ensure that they are scrollable if one of the text boxes is large.