### PR TITLE
Clear focus after pressing a NXPushButton

### DIFF
--- a/src/nexpy/gui/dialogs.py
+++ b/src/nexpy/gui/dialogs.py
@@ -4164,7 +4164,6 @@ class ViewTab(NXTab):
     def save_scalar_fields(self):
         if not self.group.is_modifiable():
             self.display_message('Group is read-only')
-            self.save_button.clearFocus()
             return
         row = 1
         for row in range(1, self.grid.rowCount()):
@@ -4183,7 +4182,6 @@ class ViewTab(NXTab):
                     return
                 if not np.isclose(field.nxvalue, value):
                     field.nxdata = value
-        self.save_button.clearFocus()
 
 
 class ViewTableModel(QtCore.QAbstractTableModel):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -3169,6 +3169,11 @@ class NXPushButton(QtWidgets.QPushButton):
         else:
             self.parent().keyPressEvent(event)
 
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
+        """Clear focus after a mouse release event."""
+        super().mouseReleaseEvent(event)
+        self.clearFocus()
+
 
 class NXColorButton(QtWidgets.QPushButton):
 


### PR DESCRIPTION
* Adds a mouseReleaseEvent function to NXPushButton so that a button does not remain active after a mouse press.