### PR TITLE
Add subentry selector and fix dark mode styling

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -192,6 +192,7 @@ class MainWindow(QtWidgets.QMainWindow):
         when the application was last run. If so, a message is displayed
         to the user to manage the plugins.
         """
+        define_mode()
         if self.new_plugins:
             display_message(
                 "New plugins are available",

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -1023,11 +1023,7 @@ def in_dark_mode():
     """
     Return True if the application is in dark mode, False otherwise.
 
-    This works by comparing the value of the window and windowText
-    colors in the application's palette. If the window color is darker
-    than the windowText color, the application is in dark mode.
-    Otherwise, it is in light mode. If the application is not properly
-    initialized, this function will return False.
+    Uses the OS-level dark mode setting detected via darkdetect.
 
     Returns
     -------
@@ -1057,7 +1053,7 @@ def define_mode():
         mainwindow.shell.colors = 'linux'
         mainwindow.statusBar().setPalette(mainwindow.app.app.palette())
         mainwindow.treeview.setStyleSheet(
-            'QTreeView { background-color: #121212; }')
+            'QTreeView { background-color: #121212; color: white; }')
     else:
         mainwindow.console.set_default_style()
         mainwindow.shell.colors = 'lightbg'
@@ -1074,8 +1070,10 @@ def define_mode():
     for plotview in mainwindow.plotviews.values():
         if in_dark_mode():
             plotview.otab.setStyleSheet('color: white')
+            plotview.tab_widget.setStyleSheet('color: white')
         else:
             plotview.otab.setStyleSheet('color: black')
+            plotview.tab_widget.setStyleSheet('color: black')
 
 
 def rotate_point(point, angle=45.0, center=[0.0, 0.0], aspect=1.0):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -754,7 +754,8 @@ class NXWidgetMixin:
         """The selected root entry."""
         return self.tree[self.root_box.currentText()]
 
-    def select_entry(self, slot=None, text='Select Entry'):
+    def select_entry(self, slot=None, text='Select Entry',
+                     subentry=False, subentries_callback=None):
         """
         Create a dropdown box from a list of the root entries and a list
         of the entries within the selected root entry in the NeXus tree.
@@ -767,6 +768,16 @@ class NXWidgetMixin:
         text : str, optional
             The text to be displayed on the button to change the entry.
             Default is 'Select Entry'.
+        subentry : bool, optional
+            If True, add a subentry selector that shows and hides
+            dynamically based on whether the selected entry contains
+            NXsubentry groups. Default is False.
+        subentries_callback : callable, optional
+            Called with no arguments; should return a list of extra
+            subentry names to include alongside any NXsubentry groups
+            found in the selected entry (e.g. parent-defined subentries
+            not yet created in the file). Only used when subentry=True.
+            Default is None.
 
         Returns
         -------
@@ -792,9 +803,20 @@ class NXWidgetMixin:
         except Exception:
             pass
         self.data_box = None
+        self.subentry_box = None
         layout.addStretch()
         layout.addWidget(self.root_box)
         layout.addWidget(self.entry_box)
+        if subentry:
+            self._subentries_callback = subentries_callback
+            self._subentry_label = NXLabel('Subentry:')
+            self._subentry_label.setVisible(False)
+            self.subentry_box = NXComboBox()
+            self.subentry_box.setVisible(False)
+            layout.addWidget(self._subentry_label)
+            layout.addWidget(self.subentry_box)
+            self.entry_box.activated.connect(self._update_subentry_box)
+            self._update_subentry_box()
         if slot:
             layout.addWidget(NXPushButton(text, slot))
         layout.addStretch()
@@ -813,11 +835,48 @@ class NXWidgetMixin:
         self.entry_box.add(*sorted(self.tree[self.root_box.selected].entries))
         if self.data_box:
             self.switch_entry()
+        if self.subentry_box is not None:
+            self._update_subentry_box()
+
+    def _update_subentry_box(self):
+        """Populate subentry_box from the current entry's NXsubentry groups.
+
+        Shows the label and box when subentries are available; hides
+        them when the selected entry has no subentries.
+        """
+        try:
+            subentries = [s.nxname for s in self.entry.NXsubentry]
+        except Exception:
+            subentries = []
+        if self._subentries_callback:
+            try:
+                for name in self._subentries_callback():
+                    if name not in subentries:
+                        subentries.append(name)
+            except Exception:
+                pass
+        self.subentry_box.blockSignals(True)
+        self.subentry_box.clear()
+        if subentries:
+            self.subentry_box.addItems([''] + subentries)
+            self._subentry_label.setVisible(True)
+            self.subentry_box.setVisible(True)
+        else:
+            self._subentry_label.setVisible(False)
+            self.subentry_box.setVisible(False)
+        self.subentry_box.blockSignals(False)
 
     @property
     def entry(self):
         """The selected entry."""
         return self.tree[f"{self.root_box.selected}/{self.entry_box.selected}"]
+
+    @property
+    def subentry(self):
+        """The selected subentry name, or '' for the top-level entry."""
+        if self.subentry_box is not None and self.subentry_box.isVisible():
+            return self.subentry_box.selected
+        return ''
 
     def select_data(self, slot=None, text='Select Data'):
         """

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -2650,8 +2650,9 @@ class NXTextEdit(QtWidgets.QTextEdit):
             self.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
         elif align == 'right':
             self.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-        self.setStyleSheet(
-            "QTextEdit { background-color: white; padding: 2px; }")
+        self._apply_stylesheet()
+        QtWidgets.QApplication.instance().paletteChanged.connect(
+            self._apply_stylesheet)
         if autosize:
             self.setLineWrapMode(QtWidgets.QTextEdit.WidgetWidth)
             self.document().setDocumentMargin(0)
@@ -2664,6 +2665,13 @@ class NXTextEdit(QtWidgets.QTextEdit):
         self.selectionChanged.connect(self.highlighter.setSearchText)
         if slot:
             self.textChanged.connect(slot)
+
+    def _apply_stylesheet(self):
+        if in_dark_mode():
+            self.setStyleSheet("QTextEdit { padding: 2px; }")
+        else:
+            self.setStyleSheet(
+                "QTextEdit { background-color: white; padding: 2px; }")
 
     def update_minimum_height(self):
         """Calculate height for one line of text including all margins"""


### PR DESCRIPTION
## Add subentry selector to `select_entry`

- `select_entry()` gains two new optional parameters: `subentry` (bool)
  and `subentries_callback` (callable)
- When `subentry=True`, a dynamically shown/hidden combo box appears
  below the entry selector, populated with any `NXsubentry` groups
  found in the selected entry
- `subentries_callback` allows callers to inject additional subentry
  names not yet present in the file (e.g. parent-defined subentries)
- A `subentry` property returns the currently selected subentry name,
  or `''` when no subentry is selected or the box is hidden

## Dark mode styling fixes

- `define_mode()` is now called at startup so light/dark styling is
  applied immediately on launch
- Dark mode treeview stylesheet gains `color: white` to ensure text
  is visible against the dark background
- Plot view `tab_widget` now receives explicit color styling so tab
  labels render correctly in both modes
- `NXTextEdit` no longer hardcodes a white background; it listens to
  the `paletteChanged` signal and applies a palette-aware stylesheet
