### PR TITLE
Mark deprecated groups in the tree view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ src/nexpy/_version.py
 
 # uv
 uv.lock
+
+# Claude
+.claude

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -403,7 +403,9 @@ class NXTreeItem(QtGui.QStandardItem):
         elif role == QtCore.Qt.ForegroundRole:
             try:
                 node = self.node
-                if isinstance(node, (NXentry, NXsubentry)):
+                if 'deprecated' in node.attrs:
+                    return QtGui.QColor('#9CA3AF')
+                elif isinstance(node, (NXentry, NXsubentry)):
                     return QtGui.QColor('#3D85C6')
                 elif isinstance(node, NXdata):
                     return QtGui.QColor('#10B981')
@@ -413,9 +415,11 @@ class NXTreeItem(QtGui.QStandardItem):
             try:
                 tree = self.node.short_tree
                 if tree.count('\n') > 50:
-                    return '\n'.join(tree.split('\n')[0:50])+'\n...'
-                else:
-                    return tree
+                    tree = '\n'.join(tree.split('\n')[0:50]) + '\n...'
+                if 'deprecated' in self.node.attrs:
+                    tree = ('⚠ DEPRECATED — this group should no longer '
+                            'be used.\n\n' + tree)
+                return tree
             except Exception:
                 return ''
 


### PR DESCRIPTION
## Summary

- Items whose underlying NeXus node carries a `deprecated` attribute are now
  drawn in neutral grey (`#9CA3AF`) in the tree view. The colour reads as
  visibly faded against both light and dark backgrounds without becoming
  illegible (contrast ≈ 2.9 on white, ≈ 7.1 on a typical dark theme), and it
  takes precedence over the existing `NXentry` / `NXsubentry` (`#3D85C6`)
  and `NXdata` (`#10B981`) colours so a deprecated entry no longer reads as
  a normal entry-blue group.
- The tooltip on a deprecated item is prepended with a one-line
  `⚠ DEPRECATED — this group should no longer be used.` banner above the
  existing short-tree summary, so a user hovering on a faded item
  immediately sees why.
- The check uses the same `'deprecated' in node.attrs` pattern already in
  use elsewhere in `treeview.py`; any group or field written with that
  attribute is treated automatically. (nxrefine uses this on legacy
  `/entry/nxreduce` groups once the parent file's `nxscans/settings`
  becomes canonical.)
- Add `.claude/` to `.gitignore` so per-session editor-assistance scratch
  files don't show up in `git status`.

## Test plan

- [ ] Open a NeXus file containing a group with `attrs['deprecated']` set
      (e.g. an nxrefine wrapper file that has been touched by `nxmax` or
      `nxpdf` on the latest nxrefine main); confirm `/entry/nxreduce` is
      rendered in grey.
- [ ] Hover over that group; confirm the tooltip starts with the
      "DEPRECATED" banner and is followed by the usual short tree.
- [ ] Repeat under both light and dark themes; confirm the grey remains
      legible in each.
- [ ] Confirm normal (non-deprecated) `NXentry` and `NXdata` items still
      render in their existing blue/green colours.
