### PR TITLE
Fix segfault when removing a tree item on Linux

### DIFF
--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -89,17 +89,17 @@ class NXtree(NXgroup):
         """
         self.sync_shell_names()
         if self._model:
-            self.sync_children(self._item)
+            self.sync_children(self._model.invisibleRootItem(), self)
             for row in range(self._item.rowCount()):
                 for item in self._item.child(row).walk():
-                    self.sync_children(item)
+                    self.sync_children(item, item.node)
             index = self._item.index()
             if index.isValid():
                 self._view.dataChanged(index, index)
             self._view.update()
             self._view.status_message(self._view.node)
 
-    def sync_children(self, item):
+    def sync_children(self, item, node):
         """
         Synchronize the children of a tree item with its NeXus group.
 
@@ -110,23 +110,36 @@ class NXtree(NXgroup):
 
         Parameters
         ----------
-        item : NXTreeItem
-            The tree item to be synchronized.
+        item : QStandardItem
+            The tree item to be synchronized. For the top-level call
+            this is the model's invisible root item; otherwise it is
+            an NXTreeItem.
+        node : NXgroup
+            The NeXus group whose entries should mirror ``item``'s
+            children. Passed explicitly so the top-level call does not
+            depend on an attribute attached to the invisible root item,
+            whose PyQt wrapper is not guaranteed to persist.
         """
-        if isinstance(item.node, NXgroup):
+        if isinstance(node, NXgroup):
             children = []
             if item.hasChildren():
                 for row in range(item.rowCount()):
                     children.append(item.child(row))
             names = [child.name for child in children]
-            if item.node.entries_loaded:
-                for name in item.node:
+            if node.entries_loaded:
+                for name in node:
                     if name not in names:
-                        item.appendRow(NXTreeItem(item.node[name]))
-                for child in children:
-                    if child.name not in item.node:
-                        item.removeRow(child.row())
-        item.node.set_unchanged()
+                        item.appendRow(NXTreeItem(node[name]))
+                stale = [c for c in children if c.name not in node]
+                if stale and self._view is not None:
+                    self._view.selectionModel().clearSelection()
+                    self._view.setCurrentIndex(QtCore.QModelIndex())
+                for child in sorted(stale, key=lambda c: c.row(),
+                                    reverse=True):
+                    row = child.row()
+                    if row >= 0:
+                        item.removeRow(row)
+        node.set_unchanged()
 
     def add(self, node):
         """
@@ -475,7 +488,6 @@ class NXTreeView(QtWidgets.QTreeView):
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         self.tree._item = self._model.invisibleRootItem()
-        self.tree._item.node = self.tree
         self.tree._model = self._model
         self.tree._view = self
         self.tree._shell = self.mainwindow.user_ns


### PR DESCRIPTION
## Summary

- Removing an `NXroot` via the tree-view right-click → Remove menu
  consistently segfaulted on Linux (PyQt5/Qt5). The crash happened
  inside `NXtree.sync_children`'s `item.removeRow(...)` call on the
  model's invisible root. Not reproducible on macOS, presumably because
  Qt's event delivery during model mutation differs.
- Root cause: with `setDynamicSortFilter(True)` on the `NXSortModel`
  proxy, Qt updates the selection model and re-sorts during row removal,
  invoking `NXSortModel.lessThan` which dereferences the item Qt is in
  the middle of destroying (`itemFromIndex(...).text()`). That's a NULL
  C++ deref that Python `try/except` cannot catch.
- Fix: clear the view's selection and current index before any rows are
  removed, so the selection model has nothing to remap during the
  destruction. Diagnostic confirmed via a `QSignalBlocker` test —
  blocking signals around `removeRow` prevented the crash but left a
  dangling expand arrow; clearing the selection up front makes
  signal-driven cleanup safe and the view stays in sync.

Two related defensive changes are included since they're in the same
flow and touch the same `sync_children` method:

- The remove loop now iterates from the highest row down and guards
  `row >= 0` so a child already detached cannot trigger an out-of-range
  removal.
- `sync_children` takes the node as an explicit second argument instead
  of reading `item.node` on the model's invisible root item. The root
  item's `.node` attribute was monkey-patched at view construction
  (`self.tree._item.node = self.tree`), but PyQt's wrapper for items it
  did not create is not guaranteed to persist — sip may regenerate it,
  dropping the attribute. That monkey-patch is also removed.

## Test plan

- [x] Linux: right-click any loaded tree → Remove. No crash; tree
      disappears cleanly with no dangling expand arrow.
- [x] Linux: File → Remove All with multiple trees loaded.
- [x] Linux: right-click a tree that is *not* currently selected and
      Remove it. (Qt auto-selects on right-click, but the path through
      `clearSelection()` remains correct.)
- [ ] macOS: regression check — right-click → Remove and Remove All
      still work normally.
