### PR TITLE
Persist rotation cut lines with color matching and close-signal cleanup

### DIFF
--- a/src/nexpy/gui/plotview.py
+++ b/src/nexpy/gui/plotview.py
@@ -311,6 +311,8 @@ class NXPlotView(QtWidgets.QDialog):
         y-axis, and 2 for the x-axis.
     """
 
+    view_closed = QtCore.Signal(str)
+
     def __init__(self, label=None, mainwindow=None, parent=None):
 
         """
@@ -404,6 +406,7 @@ class NXPlotView(QtWidgets.QDialog):
         self.ymin = self.ymax = None
         self.vmin = self.vmax = None
         self.plots = {}
+        self.cut_lines = {}
 
         self.image = None
         self.colorbar = None
@@ -3080,10 +3083,22 @@ class NXPlotView(QtWidgets.QDialog):
 
     def close_view(self):
         """Remove this window from menus and close associated panels."""
+        self.view_closed.emit(self.label)
         self.remove_menu_action()
         if self.label in plotviews:
             del plotviews[self.label]
         self.remove_panels()
+
+    def on_cut_view_closed(self, label):
+        """Remove persistent cut lines when their cut window is closed."""
+        if label in self.cut_lines:
+            for line in self.cut_lines[label]:
+                try:
+                    line.remove()
+                except Exception:
+                    pass
+            del self.cut_lines[label]
+            self.canvas.draw()
 
     def closeEvent(self, event):
         """Close this widget and mark it for deletion."""
@@ -4353,7 +4368,8 @@ class NXProjectionTab(QtWidgets.QWidget):
         event : QMouseEvent
             The mouse event that triggered the drawing of the line.
         """
-        self.rotate_line = NXline(self.plotview, self.plot_rotated_line)
+        self.rotate_line = NXline(self.plotview, self.plot_rotated_line,
+                                  persist=True)
         self.rotate_line.on_press(event)
 
     def plot_rotated_line(self, start, end):
@@ -4428,6 +4444,15 @@ class NXProjectionTab(QtWidgets.QWidget):
         legend_label = f"{rotation_angle:.0f}° y = {rotated_y:.2f}"
         plotviews[label].plots[idx]['legend_label'] = legend_label
         plotviews[label].legend()
+        color = plotviews[label].plots[idx]['color']
+        line = self.rotate_line.line
+        line.set_color(color)
+        line.set_linestyle('--')
+        line.set_linewidth(2)
+        if label not in self.plotview.cut_lines:
+            self.plotview.cut_lines[label] = []
+            plotviews[label].view_closed.connect(self.plotview.on_cut_view_closed)
+        self.plotview.cut_lines[label].append(line)
 
 
 class NXNavigationToolbar(NavigationToolbar2QT):

--- a/src/nexpy/gui/widgets.py
+++ b/src/nexpy/gui/widgets.py
@@ -4792,7 +4792,7 @@ class NXpolygon(NXpatch):
 
 class NXline:
 
-    def __init__(self, plotview=None, callback=None):
+    def __init__(self, plotview=None, callback=None, persist=False):
         """
         Initialize the NXline object.
 
@@ -4805,6 +4805,9 @@ class NXline:
             A callback function to be called when the line is drawn. The
             function should take two arguments, the x and y values of
             the line. If None, the default is to do nothing.
+        persist : bool, optional
+            If True, the line is not removed after release; the caller
+            is responsible for removing it. Default is False.
         """
         if plotview:
             self.plotview = plotview
@@ -4812,6 +4815,7 @@ class NXline:
             from .plotview import get_plotview
             self.plotview = get_plotview()
         self.callback = callback
+        self.persist = persist
         self.ax = self.plotview.ax
         self.canvas = self.plotview.canvas
         self.line = None
@@ -4866,5 +4870,6 @@ class NXline:
         if self.callback:
             self.callback(self.start_point, self.end_point)
         self.disconnect()
-        self.line.remove()
+        if not self.persist:
+            self.line.remove()
         self.canvas.draw()


### PR DESCRIPTION
## Summary

- Dashed lines drawn by shift-dragging on a 2D plot now remain visible
  in the original window as long as their "Rotation: ..." cut window is open
- Each persistent line is styled to match the color of its corresponding
  cut curve in the new window, so lines and cuts can be visually paired
- Closing the cut window automatically removes all associated dashed lines
  from the original plot

## Implementation

- `NXline` (`widgets.py`): added `persist=False` parameter; when `True`,
  `on_release` skips `line.remove()` so the caller owns the line lifetime
- `NXPlotView` (`plotview.py`): added a `view_closed = QtCore.Signal(str)`
  class signal emitted in `close_view`, a `cut_lines` dict to track
  persistent lines per cut-window label, and an `on_cut_view_closed` slot
  that removes them on signal receipt
- `NXProjectionTab.plot_rotated_line` (`plotview.py`): retrieves the
  Matplotlib color-cycle color from the new cut's plot dict, restyles the
  temporary white dotted line to a colored dashed line, connects the
  `view_closed` signal on the first cut for each window, and appends the
  line to `cut_lines`

## Test plan

- [ ] Shift-drag on a 2D plot → dashed colored line persists in the original
      window and a "Rotation: ..." cut window opens
- [ ] Shift-drag again → second dashed line appears in the next Matplotlib
      color; cut window gains a second over-plotted curve of the matching color
- [ ] Close the "Rotation: ..." window → all dashed lines disappear from the
      original plot
- [ ] Normal (non-shift) button presses are unaffected
- [ ] Closing the original plot window before the cut window raises no errors
