### PR TITLE
Guard against stale dialog wrappers when switching display mode

### DIFF
--- a/src/nexpy/gui/mainwindow.py
+++ b/src/nexpy/gui/mainwindow.py
@@ -2188,7 +2188,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         If an exception is raised, it is ignored.
         """
-        windows = self.dialogs
+        windows = list(self.dialogs)
         windows += [self.plotviews[pv]
                     for pv in self.plotviews if pv != 'Main']
         for window in windows:

--- a/src/nexpy/gui/utils.py
+++ b/src/nexpy/gui/utils.py
@@ -1060,12 +1060,23 @@ def define_mode():
         mainwindow.statusBar().setPalette(mainwindow.app.app.palette())
         mainwindow.treeview.setStyleSheet('')
 
+    stale = []
     for dialog in mainwindow.dialogs:
-        if dialog.windowTitle() == 'Script Editor':
+        try:
+            title = dialog.windowTitle()
+        except RuntimeError:
+            stale.append(dialog)
+            continue
+        if title == 'Script Editor':
             for tab in [dialog.tabs[t] for t in dialog.tabs]:
                 tab.define_style()
-        elif dialog.windowTitle().startswith('Log File'):
+        elif title.startswith('Log File'):
             dialog.switch_mode()
+    for dialog in stale:
+        try:
+            mainwindow.dialogs.remove(dialog)
+        except ValueError:
+            pass
 
     for plotview in mainwindow.plotviews.values():
         if in_dark_mode():


### PR DESCRIPTION
## Summary

- Switching macOS system appearance between light and dark could hang NeXpy with `RuntimeError: wrapped C/C++ object of type NXDialog has been deleted`, raised from `define_mode` in `src/nexpy/gui/utils.py`. If a dialog's C++ object had been destroyed without its `closeEvent`/`cleanup` running, `mainwindow.dialogs` still held the dead Python wrapper, and calling `windowTitle()` on it propagated out of the palette-change handler and stalled the GUI event loop.
- `define_mode` now catches `RuntimeError` per dialog and prunes the stale entries from `mainwindow.dialogs` so subsequent palette changes stay clean.
- Also fixes `close_window` in `mainwindow.py`, which did `windows = self.dialogs` followed by `windows += [...]`. Because `+=` on a list mutates in place, every invocation silently appended the plotviews to `self.dialogs`. Use `list()` to take a copy.

## Test plan

- [ ] Open several dialogs (Script Editor, Log File, plot panels), leave the session running long enough that some dialogs are closed and garbage-collected, then toggle the macOS system appearance between Light and Dark — the palette change should complete without a `RuntimeError` and without freezing the UI.
- [ ] Toggle the appearance again after the first switch and confirm no stale dialogs reappear in subsequent iterations (i.e. the pruning works).
- [ ] Invoke "Close Window" (the active-window close action) multiple times in a row and confirm `mainwindow.dialogs` does not grow on each call.
