### PR TITLE
Replace tree-view emoji prefixes with QIcon decorations

### DIFF
--- a/src/nexpy/gui/resources/tree-link.svg
+++ b/src/nexpy/gui/resources/tree-link.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <path fill="none" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M7 5H4.5a2.5 2.5 0 0 0 0 5H7"/>
+  <path fill="none" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M9 5h2.5a2.5 2.5 0 0 1 0 5H9"/>
+  <line x1="5.5" y1="7.5" x2="10.5" y2="7.5" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/nexpy/gui/resources/tree-lock.svg
+++ b/src/nexpy/gui/resources/tree-lock.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <path fill="none" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M5 7V5a3 3 0 0 1 6 0v2"/>
+  <rect x="3.5" y="7" width="9" height="7" rx="1.2" fill="#6B7280"/>
+</svg>

--- a/src/nexpy/gui/resources/tree-modified.svg
+++ b/src/nexpy/gui/resources/tree-modified.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#E03D10" stroke-width="1.5"/>
+  <line x1="3.76" y1="3.76" x2="12.24" y2="12.24" stroke="#E03D10" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -12,8 +12,22 @@ from nexusformat.nexus import (NeXusError, NXdata, NXentry, NXfield, NXgroup,
                                NXlink, NXroot, NXsubentry, nxload)
 
 from .pyqt import QtCore, QtGui, QtWidgets
-from .utils import (display_message, get_name, modification_time, report_error)
+from .utils import (display_message, get_name, modification_time, report_error,
+                    resource_icon)
 from .widgets import NXSortModel
+
+
+_tree_icons = {}
+
+
+def _tree_icon(name):
+    """Return a cached QIcon for a tree-view decoration.
+
+    Populated lazily so a QApplication exists before any QIcon is built.
+    """
+    if name not in _tree_icons:
+        _tree_icons[name] = resource_icon(f'tree-{name}.svg')
+    return _tree_icons[name]
 
 
 class NXtree(NXgroup):
@@ -380,30 +394,26 @@ class NXTreeItem(QtGui.QStandardItem):
 
         Returns
         -------
-        str or None
-            The name of the tree item (with emoji prefix for root and link
-            nodes) for DisplayRole, the plain name for EditRole, and a
-            tooltip string for ToolTipRole.
+        str, QIcon, QColor, or None
+            The item name for DisplayRole and EditRole, an icon flagging
+            read-only / modified / link state for DecorationRole, a
+            foreground color for ForegroundRole, or a tooltip string for
+            ToolTipRole.
         """
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole:
+            return self.name
+        elif role == QtCore.Qt.DecorationRole:
             try:
                 node = self.node
                 if isinstance(node, NXroot):
                     if node._file_modified:
-                        prefix = '🚫'
+                        return _tree_icon('modified')
                     elif node.nxfilemode == 'r':
-                        prefix = '🔒'
-                    else:
-                        prefix = None
+                        return _tree_icon('lock')
                 elif isinstance(node, NXlink):
-                    prefix = '🔗'
-                else:
-                    prefix = None
+                    return _tree_icon('link')
             except Exception:
-                prefix = None
-            return f'{prefix} {self.name}' if prefix else self.name
-        elif role == QtCore.Qt.EditRole:
-            return self.name
+                pass
         elif role == QtCore.Qt.ForegroundRole:
             try:
                 node = self.node


### PR DESCRIPTION
## Summary

- The 🔒, 🚫, and 🔗 prefixes that `NXTreeItem` added to read-only, externally modified, and `NXlink` nodes rendered correctly on macOS and Windows but disappeared on modern Linux. Fedora has switched `google-noto-color-emoji-fonts` to a COLRv1-only build, and fontconfig now points these codepoints at fonts (Source Code Pro, Symbola) that either lack the glyph or that Qt cannot render in color. Confirmed broken under both PyQt5 5.15 and PyQt6 6.11, so this is not fixable by bumping Qt.
- `NXTreeItem.data()` now returns the plain name for `DisplayRole`/`EditRole` and a bundled `QIcon` for `DecorationRole`, dispatching on the same node-type logic the emoji prefix used. Three SVGs (`tree-lock.svg`, `tree-modified.svg`, `tree-link.svg`) are added under `src/nexpy/gui/resources/`, all 16×16 monochrome: neutral slate gray for the lock and link, red (matching the existing modified-file foreground `#E03D10`) for the prohibited mark.
- Icons are loaded via the existing `resource_icon()` helper and lazily cached in a module-level dict, so a `QApplication` is guaranteed to exist before any `QIcon` is built and the cache is not rebuilt on every repaint. The red `ForegroundRole` for modified files is unchanged.

## Test plan

- [ ] On Linux (where emoji were broken): open NeXpy and confirm a lock icon appears next to read-only roots, a red circle-with-slash next to externally modified roots, and a link icon next to `NXlink` groups.
- [ ] On macOS and Windows: confirm the same icons render and that no leading emoji characters remain.
- [ ] Toggle dark/light system appearance and confirm all three icons stay visible with adequate contrast against both backgrounds.
- [ ] Right-click → rename a flagged tree item and confirm the edit field contains just the plain name, with no leading character to backspace through.
- [ ] Confirm sort order is unaffected by the prefix removal — items now sort by their plain names.
- [ ] `pytest` still passes; `grep -RnP "🔒|🚫|🔗" src/ tests/` is empty.
