### PR TITLE
Prune stale NXTreeItems when their backing node is gone

### DIFF
--- a/src/nexpy/gui/treeview.py
+++ b/src/nexpy/gui/treeview.py
@@ -105,8 +105,19 @@ class NXtree(NXgroup):
         if self._model:
             self.sync_children(self._model.invisibleRootItem(), self)
             for row in range(self._item.rowCount()):
-                for item in self._item.child(row).walk():
-                    self.sync_children(item, item.node)
+                for item in list(self._item.child(row).walk()):
+                    try:
+                        node = item.node
+                        if node is None:
+                            parent = (item.parent()
+                                      or self._model.invisibleRootItem())
+                            item_row = item.row()
+                            if item_row >= 0:
+                                parent.removeRow(item_row)
+                            continue
+                        self.sync_children(item, node)
+                    except RuntimeError:
+                        continue
             index = self._item.index()
             if index.isValid():
                 self._view.dataChanged(index, index)
@@ -374,7 +385,10 @@ class NXTreeItem(QtGui.QStandardItem):
     @property
     def node(self):
         """The selected node in the tree."""
-        return self.tree[self.path]
+        try:
+            return self.tree[self.path]
+        except NeXusError:
+            return None
 
     def __repr__(self):
         return f"NXTreeItem('{self.path}')"


### PR DESCRIPTION
## Summary

A file reload that removes a NeXus group will leave the tree model holding `NXTreeItem` instances whose `self.path` strings still point at the missing path. The next `NXtree.set_changed` walks every materialised item via `NXTreeItem.walk` and accesses `item.node` on each, which raised `"'<root>/<entry>/<group>' is an invalid path"` from `NXgroup.__getitem__` as soon as the lookup hit the missing component. Tree redraw broke unconditionally — even with everything collapsed, because the items persist behind collapsed rows.

This makes reload robust to structural mutations done outside NeXpy (or by a plugin between reloads):

- `NXTreeItem.node` returns `None` instead of raising when its stored path is no longer in the tree.
- `NXtree.set_changed` removes any item whose `.node` is `None` from its parent row before calling `sync_children`.

## Why existing callers aren't newly exposed

- The Qt data-role accessors in `NXTreeItem.data` already wrap `self.node` in `try/except Exception` for icons, foreground colour, and tooltip.
- The menu/action checks (e.g. `if item and item.node:` at the QAction enable sites) already handled a falsy node.
- `NXTreeView.get_node` could already return `None` for an empty selection, so callers that did `node.something` directly were already exposed to the `None` case.

## Test plan

- [ ] Open a NeXus file with a group at, e.g., `/entry/nxcombine`. Expand the tree to make sure the `NXTreeItem` is materialised. Collapse it again.
- [ ] In a Python console, delete that group (`del root['entry/nxcombine']`) or replace it.
- [ ] Reload the workspace from NeXpy. Confirm no `"'<path>' is an invalid path"` error appears and the tree updates cleanly with the stale item removed.
- [ ] Verify normal reload of a file with no structural changes still works (no spurious row removals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)